### PR TITLE
Ajout de Execute_SQL dans provider.py

### DIFF
--- a/raepa/processing/provider.py
+++ b/raepa/processing/provider.py
@@ -6,6 +6,7 @@ __revision__ = '$Format:%H$'
 from qgis.PyQt.QtGui import QIcon
 from qgis.core import QgsProcessingProvider
 
+from .algorithms.execute_sql import ExecuteSql
 from .algorithms.add_styles import AddStyles
 from .algorithms.cancel_last_modification import CancelLastModification
 from .algorithms.configure_plugin import ConfigurePlugin
@@ -33,6 +34,7 @@ class RaepaProvider(QgsProcessingProvider):
         return QIcon(resources_path('icons/icon.png'))
 
     def loadAlgorithms(self):
+        self.addAlgorithm(ExecuteSql())
         self.addAlgorithm(AddSqlLayers())
         self.addAlgorithm(AddStyles())
         self.addAlgorithm(CancelLastModification())


### PR DESCRIPTION
L'action `couper_la_canalisation_sous_cet_ouvrage` essaye :

`processing.run('raepa:execute_sql', params)`

Or `execute_sql` n'était pas chargé dans les outils du plugin et donc on obtenais une erreur :
**'Erreur dans les logs de Processing/PostGIS.'**

Pour corriger cette erreur, il a fallut ajouter dans `provider.py` le chargement de `execute_sql` afin que `processing.run` puisse le lancer.
