### PR TITLE
Possibilité de définir le nom de la couche de sortie

### DIFF
--- a/raepa/processing/algorithms/get_downstream_route.py
+++ b/raepa/processing/algorithms/get_downstream_route.py
@@ -82,4 +82,6 @@ class GetDownstreamRoute(GetDataAsLayer):
         self.SQL = sql.replace('\n', ' ').rstrip(';')
 
     def setLayerName(self, parameters, context, feedback):
-        self.LAYER_NAME = 'Réseau aval depuis {}'.format(parameters[self.SOURCE_ID])
+        super().setLayerName(parameters, context, feedback)
+        if self.LAYER_NAME == '':
+            self.LAYER_NAME = 'Réseau aval depuis {}'.format(parameters[self.SOURCE_ID])

--- a/raepa/processing/algorithms/get_network_to_vanne.py
+++ b/raepa/processing/algorithms/get_network_to_vanne.py
@@ -74,4 +74,6 @@ class GetNetworkToVanne(GetDataAsLayer):
         self.SQL = sql.replace('\n', ' ').rstrip(';')
 
     def setLayerName(self, parameters, context, feedback):
-        self.LAYER_NAME = 'Réseau vers la vanne depuis {}'.format(parameters[self.SOURCE_ID])
+        super().setLayerName(parameters, context, feedback)
+        if self.LAYER_NAME == '':
+            self.LAYER_NAME = 'Réseau vers la vanne depuis {}'.format(parameters[self.SOURCE_ID])

--- a/raepa/processing/algorithms/get_network_to_vanne_ferme_from_point.py
+++ b/raepa/processing/algorithms/get_network_to_vanne_ferme_from_point.py
@@ -79,4 +79,6 @@ class GetNetworkToVanneFermeFromPoint(GetDataAsLayer):
         self.SQL = sql.replace('\n', ' ').rstrip(';')
 
     def setLayerName(self, parameters, context, feedback):
-        self.LAYER_NAME = 'Réseau jusqu\'aux vannes fermées depuis {}'.format(self.parameterAsString(parameters, self.POINT, context))
+        super().setLayerName(parameters, context, feedback)
+        if self.LAYER_NAME == '':
+            self.LAYER_NAME = 'Réseau jusqu\'aux vannes fermées depuis {}'.format(self.parameterAsString(parameters, self.POINT, context))

--- a/raepa/processing/algorithms/get_network_to_vanne_from_point.py
+++ b/raepa/processing/algorithms/get_network_to_vanne_from_point.py
@@ -82,4 +82,6 @@ class GetNetworkToVanneFromPoint(GetDataAsLayer):
         self.SQL = sql.replace('\n', ' ').rstrip(';')
 
     def setLayerName(self, parameters, context, feedback):
-        self.LAYER_NAME = 'Réseau jusqu\'aux vannes depuis {}'.format(self.parameterAsString(parameters, self.POINT, context))
+        super().setLayerName(parameters, context, feedback)
+        if self.LAYER_NAME == '':
+            self.LAYER_NAME = 'Réseau jusqu\'aux vannes depuis {}'.format(self.parameterAsString(parameters, self.POINT, context))

--- a/raepa/processing/algorithms/get_upstream_route.py
+++ b/raepa/processing/algorithms/get_upstream_route.py
@@ -84,4 +84,6 @@ class GetUpstreamRoute(GetDataAsLayer):
         self.SQL = sql.replace('\n', ' ').rstrip(';')
 
     def setLayerName(self, parameters, context, feedback):
-        self.LAYER_NAME = 'Réseau amout depuis {}'.format(parameters[self.SOURCE_ID])
+        super().setLayerName(parameters, context, feedback)
+        if self.LAYER_NAME == '':
+            self.LAYER_NAME = 'Réseau amont depuis {}'.format(parameters[self.SOURCE_ID])


### PR DESCRIPTION
Les fonctionnalités qui en sortie créent une couche, héritent de la classe `GetDataAsLayer` dans laquelle on retrouve la méthode `setLayerName()` qui permet de donner a la couche sortie le le nom choisit par l'utilisateur.

Or dans chacune des sous classes de `GetDataAsLayer`, cette méthode était réécrite afin de pouvoir donner un nom générique a la couche et écrasait la méthode de la classe mère.
Il a donc fallu rajouter dans les méthodes des classes filles un appel a la méthode de `GetDataAsLayer`.
