### PR TITLE
Delete Input Parameters

### DIFF
--- a/raepa/processing/algorithms/cancel_last_modification.py
+++ b/raepa/processing/algorithms/cancel_last_modification.py
@@ -54,12 +54,8 @@ class CancelLastModification(ExecuteSql):
         super(self.__class__, self).initAlgorithm(config)
 
         # INPUTS
-        self.addParameter(
-            QgsProcessingParameterVectorLayer(
-                self.SOURCE_LAYER, 'Source layer',
-                optional=False
-            )
-        )
+        self.removeParameter('INPUT_SQL')
+
         self.addParameter(
             QgsProcessingParameterString(
                 self.SOURCE_ID, 'Unique ID (id)',

--- a/raepa/processing/algorithms/cancel_last_modification.py
+++ b/raepa/processing/algorithms/cancel_last_modification.py
@@ -57,6 +57,13 @@ class CancelLastModification(ExecuteSql):
         self.removeParameter('INPUT_SQL')
 
         self.addParameter(
+            QgsProcessingParameterVectorLayer(
+                self.SOURCE_LAYER, 'Source layer',
+                optional=False
+            )
+        )
+
+        self.addParameter(
             QgsProcessingParameterString(
                 self.SOURCE_ID, 'Unique ID (id)',
                 defaultValue=-1,

--- a/raepa/processing/algorithms/convert_imported_data.py
+++ b/raepa/processing/algorithms/convert_imported_data.py
@@ -61,6 +61,8 @@ class ConvertImportedData(ExecuteSql):
         super(self.__class__, self).initAlgorithm(config)
 
         # INPUTS
+        self.removeParameter('INPUT_SQL')
+
         self.addParameter(
             QgsProcessingParameterString(
                 self.ANNEE_FIN_POSE, 'Année de fin de pose',

--- a/raepa/processing/algorithms/get_orientation_appareil.py
+++ b/raepa/processing/algorithms/get_orientation_appareil.py
@@ -55,6 +55,8 @@ class GetOrientationAppareil(ExecuteSql):
         super(self.__class__, self).initAlgorithm(config)
 
         # INPUTS
+        self.removeParameter('INPUT_SQL')
+
         self.addParameter(
             QgsProcessingParameterString(
                 self.SOURCE_ID, 'Unique ID (idappareil)',

--- a/raepa/processing/algorithms/insert_converted_data.py
+++ b/raepa/processing/algorithms/insert_converted_data.py
@@ -54,6 +54,8 @@ class InsertConvertedData(ExecuteSql):
         super(self.__class__, self).initAlgorithm(config)
 
         # INPUTS
+        self.removeParameter('INPUT_SQL')
+
         self.addParameter(
             QgsProcessingParameterString(
                 self.SOURCE_HISTORIQUE, 'Source historique',


### PR DESCRIPTION
Suppression du paramètre d'entrée `INPUT_SQL` dans plusieurs outils car il était inutile. 