### PR TITLE
Correction calcul d'orientation

### DIFF
--- a/raepa/install/sql/raepa/10_FUNCTION.sql
+++ b/raepa/install/sql/raepa/10_FUNCTION.sql
@@ -34,8 +34,8 @@ BEGIN
             THEN round(CAST(degrees(ST_Azimuth(ST_StartPoint(ST_LineSubstring(cgeom, pos, pos + 0.1)),
         ST_EndPoint(ST_LineSubstring(cgeom, pos, pos + 0.1)))) as numeric), 2)
         WHEN pos >= 0.9
-            THEN round(CAST(degrees(ST_Azimuth(ST_StartPoint(ST_LineSubstring(cgeom, pos, pos)),
-        ST_EndPoint(ST_LineSubstring(cgeom, pos, pos)))) as numeric), 2)
+            THEN round(CAST(degrees(ST_Azimuth(ST_StartPoint(ST_LineSubstring(cgeom, pos - 0.1, pos)),
+        ST_EndPoint(ST_LineSubstring(cgeom, pos - 0.1, pos)))) as numeric), 2)
     END into res
     FROM raepa.raepa_apparaep_p p
     JOIN raepa.raepa_canalaep_l c ON ST_DWithin(c.geom, p.geom, 0.05);


### PR DESCRIPTION
Le calcul de l'orientation des appareils ne fonctionnait pas sur ceux qui étaient situés en bout de canalisation, car dans ce cas l'azimut était calculé sur un seul point. il est maintenant calculé entre la position de l'appareil et un point situé légèrement avant sur la canalisation.