### PR TITLE
Symbole des couches de résultat

### DIFF
--- a/.github/workflows/publish-doc.yml
+++ b/.github/workflows/publish-doc.yml
@@ -27,7 +27,7 @@ jobs:
         python-version: 3.8
 
     - name: Set up NodeJS (for search index prebuilding)
-      uses: actions/setup-node@v2.1.5
+      uses: actions/setup-node@v2.2.0
       with:
         node-version: '12'
 

--- a/raepa/processing/algorithms/get_data_as_layer.py
+++ b/raepa/processing/algorithms/get_data_as_layer.py
@@ -21,6 +21,7 @@ from db_manager.db_plugins import createDbPlugin
 from processing.tools import postgis
 from qgis.core import (
     QgsVectorLayer,
+    QgsLineSymbol,
     QgsProcessingContext,
     QgsProcessingException,
     QgsProcessingParameterString,
@@ -40,6 +41,7 @@ class GetDataAsLayer(BaseProcessingAlgorithm):
     OUTPUT_LAYER = 'OUTPUT_LAYER'
     OUTPUT_LAYER_NAME = 'OUTPUT_LAYER_NAME'
     OUTPUT_LAYER_RESULT_NAME = 'OUTPUT_LAYER_RESULT_NAME'
+    SYMBOLE = 'SYMBOLE'
 
     SQL = 'SELECT 1::int AS id'
     LAYER_NAME = ''
@@ -136,6 +138,14 @@ class GetDataAsLayer(BaseProcessingAlgorithm):
         output_layer_name = parameters[self.OUTPUT_LAYER_NAME]
         self.LAYER_NAME = output_layer_name
 
+    def setSymbole(self, parameters, context, feedback):
+        self.SYMBOLE = QgsLineSymbol.createSimple(
+            {
+                'line_color': '0,0,0',
+                'line_style': 'solid',
+                'line_width': '1'
+            })
+
     def processAlgorithm(self, parameters, context, feedback):
         """
         Here is where the processing itself takes place.
@@ -150,6 +160,8 @@ class GetDataAsLayer(BaseProcessingAlgorithm):
         self.setSql(parameters, context, feedback)
         # Set output layer name
         self.setLayerName(parameters, context, feedback)
+        # Set symbole
+        self.setSymbole(parameters, context, feedback)
 
         # Buid QGIS uri to load layer
         id_field = 'id'
@@ -162,13 +174,14 @@ class GetDataAsLayer(BaseProcessingAlgorithm):
                 Vérifier les logs de PostGIS pour des messages d\'erreurs.""")
 
         # Load layer
+        vlayer.renderer().setSymbol(self.SYMBOLE)
         context.temporaryLayerStore().addMapLayer(vlayer)
         context.addLayerToLoadOnCompletion(
             vlayer.id(),
             QgsProcessingContext.LayerDetails(
                 self.LAYER_NAME,
                 context.project(),
-                self.OUTPUT_LAYER
+                self.OUTPUT_LAYER,
             )
         )
 

--- a/raepa/processing/algorithms/get_downstream_route.py
+++ b/raepa/processing/algorithms/get_downstream_route.py
@@ -82,4 +82,6 @@ class GetDownstreamRoute(GetDataAsLayer):
         self.SQL = sql.replace('\n', ' ').rstrip(';')
 
     def setLayerName(self, parameters, context, feedback):
-        self.LAYER_NAME = 'Réseau aval depuis {}'.format(parameters[self.SOURCE_ID])
+        super().setLayerName(parameters, context, feedback)
+        if self.LAYER_NAME == '':
+            self.LAYER_NAME = 'Réseau aval depuis {}'.format(parameters[self.SOURCE_ID])

--- a/raepa/processing/algorithms/get_downstream_route.py
+++ b/raepa/processing/algorithms/get_downstream_route.py
@@ -20,6 +20,7 @@ __revision__ = '$Format:%H$'
 from .get_data_as_layer import GetDataAsLayer
 from qgis.core import (
     QgsProcessingParameterString,
+    QgsLineSymbol,
     QgsProcessingParameterEnum
 )
 
@@ -85,3 +86,13 @@ class GetDownstreamRoute(GetDataAsLayer):
         super().setLayerName(parameters, context, feedback)
         if self.LAYER_NAME == '':
             self.LAYER_NAME = 'Réseau aval depuis {}'.format(parameters[self.SOURCE_ID])
+
+    def setSymbole(self, parameters, context, feedback):
+        super().setSymbole(parameters, context, feedback)
+        self.SYMBOLE = QgsLineSymbol.createSimple(
+            {
+                'line_color': '255,50,50,255',
+                'line_style': 'solid',
+                'line_width': '1.8'
+            }
+        )

--- a/raepa/processing/algorithms/get_network_to_vanne.py
+++ b/raepa/processing/algorithms/get_network_to_vanne.py
@@ -74,4 +74,6 @@ class GetNetworkToVanne(GetDataAsLayer):
         self.SQL = sql.replace('\n', ' ').rstrip(';')
 
     def setLayerName(self, parameters, context, feedback):
-        self.LAYER_NAME = 'Réseau vers la vanne depuis {}'.format(parameters[self.SOURCE_ID])
+        super().setLayerName(parameters, context, feedback)
+        if self.LAYER_NAME == '':
+            self.LAYER_NAME = 'Réseau vers la vanne depuis {}'.format(parameters[self.SOURCE_ID])

--- a/raepa/processing/algorithms/get_network_to_vanne.py
+++ b/raepa/processing/algorithms/get_network_to_vanne.py
@@ -19,6 +19,7 @@ __revision__ = '$Format:%H$'
 
 from qgis.core import (
     QgsProcessingParameterString,
+    QgsLineSymbol
 )
 
 from .get_data_as_layer import GetDataAsLayer
@@ -77,3 +78,13 @@ class GetNetworkToVanne(GetDataAsLayer):
         super().setLayerName(parameters, context, feedback)
         if self.LAYER_NAME == '':
             self.LAYER_NAME = 'Réseau vers la vanne depuis {}'.format(parameters[self.SOURCE_ID])
+
+    def setSymbole(self, parameters, context, feedback):
+        super().setSymbole(parameters, context, feedback)
+        self.SYMBOLE = QgsLineSymbol.createSimple(
+            {
+                'line_color': '255,50,50,255',
+                'line_style': 'solid',
+                'line_width': '1.8'
+            }
+        )

--- a/raepa/processing/algorithms/get_network_to_vanne_ferme_from_point.py
+++ b/raepa/processing/algorithms/get_network_to_vanne_ferme_from_point.py
@@ -79,4 +79,6 @@ class GetNetworkToVanneFermeFromPoint(GetDataAsLayer):
         self.SQL = sql.replace('\n', ' ').rstrip(';')
 
     def setLayerName(self, parameters, context, feedback):
-        self.LAYER_NAME = 'Réseau jusqu\'aux vannes fermées depuis {}'.format(self.parameterAsString(parameters, self.POINT, context))
+        super().setLayerName(parameters, context, feedback)
+        if self.LAYER_NAME == '':
+            self.LAYER_NAME = 'Réseau jusqu\'aux vannes fermées depuis {}'.format(self.parameterAsString(parameters, self.POINT, context))

--- a/raepa/processing/algorithms/get_network_to_vanne_ferme_from_point.py
+++ b/raepa/processing/algorithms/get_network_to_vanne_ferme_from_point.py
@@ -20,6 +20,7 @@ __revision__ = '$Format:%H$'
 from .get_data_as_layer import GetDataAsLayer
 from qgis.core import (
     QgsProcessingParameterPoint,
+    QgsLineSymbol
 )
 
 
@@ -82,3 +83,13 @@ class GetNetworkToVanneFermeFromPoint(GetDataAsLayer):
         super().setLayerName(parameters, context, feedback)
         if self.LAYER_NAME == '':
             self.LAYER_NAME = 'Réseau jusqu\'aux vannes fermées depuis {}'.format(self.parameterAsString(parameters, self.POINT, context))
+
+    def setSymbole(self, parameters, context, feedback):
+        super().setSymbole(parameters, context, feedback)
+        self.SYMBOLE = QgsLineSymbol.createSimple(
+            {
+                'line_color': '255,50,50,255',
+                'line_style': 'solid',
+                'line_width': '1.8'
+            }
+        )

--- a/raepa/processing/algorithms/get_network_to_vanne_from_point.py
+++ b/raepa/processing/algorithms/get_network_to_vanne_from_point.py
@@ -20,6 +20,7 @@ __revision__ = '$Format:%H$'
 from .get_data_as_layer import GetDataAsLayer
 from qgis.core import (
     QgsProcessingParameterPoint,
+    QgsLineSymbol
 )
 
 
@@ -85,3 +86,13 @@ class GetNetworkToVanneFromPoint(GetDataAsLayer):
         super().setLayerName(parameters, context, feedback)
         if self.LAYER_NAME == '':
             self.LAYER_NAME = 'Réseau jusqu\'aux vannes depuis {}'.format(self.parameterAsString(parameters, self.POINT, context))
+
+    def setSymbole(self, parameters, context, feedback):
+        super().setSymbole(parameters, context, feedback)
+        self.SYMBOLE = QgsLineSymbol.createSimple(
+            {
+                'line_color': '255,50,50,255',
+                'line_style': 'solid',
+                'line_width': '1.8'
+            }
+        )

--- a/raepa/processing/algorithms/get_network_to_vanne_from_point.py
+++ b/raepa/processing/algorithms/get_network_to_vanne_from_point.py
@@ -82,4 +82,6 @@ class GetNetworkToVanneFromPoint(GetDataAsLayer):
         self.SQL = sql.replace('\n', ' ').rstrip(';')
 
     def setLayerName(self, parameters, context, feedback):
-        self.LAYER_NAME = 'Réseau jusqu\'aux vannes depuis {}'.format(self.parameterAsString(parameters, self.POINT, context))
+        super().setLayerName(parameters, context, feedback)
+        if self.LAYER_NAME == '':
+            self.LAYER_NAME = 'Réseau jusqu\'aux vannes depuis {}'.format(self.parameterAsString(parameters, self.POINT, context))

--- a/raepa/processing/algorithms/get_upstream_route.py
+++ b/raepa/processing/algorithms/get_upstream_route.py
@@ -19,6 +19,7 @@ __revision__ = '$Format:%H$'
 
 from qgis.core import (
     QgsProcessingParameterString,
+    QgsLineSymbol,
     QgsProcessingParameterEnum
 )
 
@@ -87,3 +88,13 @@ class GetUpstreamRoute(GetDataAsLayer):
         super().setLayerName(parameters, context, feedback)
         if self.LAYER_NAME == '':
             self.LAYER_NAME = 'Réseau amont depuis {}'.format(parameters[self.SOURCE_ID])
+
+    def setSymbole(self, parameters, context, feedback):
+        super().setSymbole(parameters, context, feedback)
+        self.SYMBOLE = QgsLineSymbol.createSimple(
+            {
+                'line_color': '50,255,50,255',
+                'line_style': 'solid',
+                'line_width': '1.8'
+            }
+        )

--- a/raepa/processing/algorithms/get_upstream_route.py
+++ b/raepa/processing/algorithms/get_upstream_route.py
@@ -84,4 +84,6 @@ class GetUpstreamRoute(GetDataAsLayer):
         self.SQL = sql.replace('\n', ' ').rstrip(';')
 
     def setLayerName(self, parameters, context, feedback):
-        self.LAYER_NAME = 'Réseau amout depuis {}'.format(parameters[self.SOURCE_ID])
+        super().setLayerName(parameters, context, feedback)
+        if self.LAYER_NAME == '':
+            self.LAYER_NAME = 'Réseau amont depuis {}'.format(parameters[self.SOURCE_ID])


### PR DESCRIPTION
Certains outils sortent comme résultat une nouvelle couche Qgis.
Or ces couches n'avaient pas la même symbologie selon si on utilisait la boite à outils ou les actions.
C'est maintenant le cas.
