### PR TITLE
Ajout styles Reparations

### DIFF
--- a/raepa/processing/algorithms/add_styles.py
+++ b/raepa/processing/algorithms/add_styles.py
@@ -35,6 +35,8 @@ class AddStyles(BaseProcessingAlgorithm):
     OUVRASS = 'OUVRASS'
     CANALAEP = 'CANALAEP'
     CANALASS = 'CANALASS'
+    REPARASS = 'REPARASS'
+    REPARAEP = 'REPARAEP'
     STYLETYPE = 'STYLETYPE'
     STYLETYPELIST = [
         ('all', 'Tout'),
@@ -113,6 +115,24 @@ class AddStyles(BaseProcessingAlgorithm):
         )
 
         self.addParameter(
+            QgsProcessingParameterVectorLayer(
+                self.REPARASS,
+                'Couche Reparation ASS',
+                optional=True,
+                types=[QgsProcessing.TypeVectorPoint]
+            )
+        )
+
+        self.addParameter(
+            QgsProcessingParameterVectorLayer(
+                self.REPARAEP,
+                'Couche Reparation AEP',
+                optional=True,
+                types=[QgsProcessing.TypeVectorPoint]
+            )
+        )
+
+        self.addParameter(
             QgsProcessingParameterEnum(
                 self.STYLETYPE, 'Importer uniquement les actions',
                 options=[s[1] for s in self.STYLETYPELIST], allowMultiple=True,
@@ -131,32 +151,42 @@ class AddStyles(BaseProcessingAlgorithm):
         layer = self.parameterAsVectorLayer(parameters, self.APPARAEP, context)
         self.load_qml_file(feedback, 'appareils_AEP.qml', layer, qml_path, styles)
 
-        feedback.setProgress(int(100 * 1 / 6))
+        feedback.setProgress(int(100 * 1 / 8))
 
         layer = self.parameterAsVectorLayer(parameters, self.APPARASS, context)
         self.load_qml_file(feedback, 'appareils_ASS.qml', layer, qml_path, styles)
 
-        feedback.setProgress(int(100 * 2 / 6))
+        feedback.setProgress(int(100 * 2 / 8))
 
         layer = self.parameterAsVectorLayer(parameters, self.OUVRAEP, context)
         self.load_qml_file(feedback, 'ouvrages_AEP.qml', layer, qml_path, styles)
 
-        feedback.setProgress(int(100 * 3 / 6))
+        feedback.setProgress(int(100 * 3 / 8))
 
         layer = self.parameterAsVectorLayer(parameters, self.OUVRASS, context)
         self.load_qml_file(feedback, 'ouvrages_ASS.qml', layer, qml_path, styles)
 
-        feedback.setProgress(int(100 * 4 / 6))
+        feedback.setProgress(int(100 * 4 / 8))
 
         layer = self.parameterAsVectorLayer(parameters, self.CANALAEP, context)
         self.load_qml_file(feedback, 'canalisations_AEP.qml', layer, qml_path, styles)
 
-        feedback.setProgress(int(100 * 5 / 6))
+        feedback.setProgress(int(100 * 5 / 8))
 
         layer = self.parameterAsVectorLayer(parameters, self.CANALASS, context)
         self.load_qml_file(feedback, 'canalisations_ASS.qml', layer, qml_path, styles)
 
-        feedback.setProgress(int(100 * 6 / 6))
+        feedback.setProgress(int(100 * 6 / 8))
+
+        layer = self.parameterAsVectorLayer(parameters, self.REPARASS, context)
+        self.load_qml_file(feedback, 'reparation_ASS.qml', layer, qml_path, styles)
+
+        feedback.setProgress(int(100 * 7 / 8))
+
+        layer = self.parameterAsVectorLayer(parameters, self.REPARAEP, context)
+        self.load_qml_file(feedback, 'reparation_AEP.qml', layer, qml_path, styles)
+
+        feedback.setProgress(int(100 * 8 / 8))
 
         return {}
 

--- a/raepa/qgis/qml/actions_reparation_AEP.qml
+++ b/raepa/qgis/qml/actions_reparation_AEP.qml
@@ -1,0 +1,16 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.10.14-A Coruña" styleCategories="Actions">
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+    <actionsetting shortTitle="" isEnabledOnlyWhenEditable="0" type="1" id="{2a1dea20-c895-477e-ac50-65733bc3ea58}" icon="" action="from qgis.utils import plugins&#xa;plugins['raepa'].run_action(&#xa;    'parcourir_reseau_depuis_cet_objet',&#xa;    '[% idouvrage %]',&#xa;    0&#xa;)" notificationMessage="" name="Parcourir le réseau depuis cet objet" capture="0">
+      <actionScope id="Feature"/>
+      <actionScope id="Canvas"/>
+      <actionScope id="Field"/>
+    </actionsetting>
+    <actionsetting shortTitle="" isEnabledOnlyWhenEditable="0" type="1" id="{370a8188-ce76-4d53-8054-2c6aff523d4c}" icon="" action="from qgis.utils import plugins&#xa;plugins['raepa'].run_action(&#xa;    'ouvrage_annuler_derniere_modification',&#xa;    '[% idouvrage %]',&#xa;    '[% @layer_id %]'&#xa;)" notificationMessage="" name="Annuler la dernière modification" capture="0">
+      <actionScope id="Feature"/>
+      <actionScope id="Canvas"/>
+    </actionsetting>
+  </attributeactions>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>

--- a/raepa/qgis/qml/actions_reparation_ASS.qml
+++ b/raepa/qgis/qml/actions_reparation_ASS.qml
@@ -1,0 +1,16 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis version="3.10.14-A Coruña" styleCategories="Actions">
+  <attributeactions>
+    <defaultAction value="{00000000-0000-0000-0000-000000000000}" key="Canvas"/>
+    <actionsetting shortTitle="" name="Parcourir le réseau depuis cet objet" icon="" notificationMessage="" type="1" id="{fdbef2bf-aed1-43ba-a9d2-e99475cdf871}" isEnabledOnlyWhenEditable="0" capture="0" action="from qgis.utils import plugins&#xa;plugins['raepa'].run_action(&#xa;    'parcourir_reseau_depuis_cet_objet',&#xa;    '[% idouvrage %]',&#xa;    0&#xa;)">
+      <actionScope id="Canvas"/>
+      <actionScope id="Field"/>
+      <actionScope id="Feature"/>
+    </actionsetting>
+    <actionsetting shortTitle="" name="Annuler la dernière modification" icon="" notificationMessage="" type="1" id="{ac2bf017-8c8b-4191-b480-c2bb5f0b4c5c}" isEnabledOnlyWhenEditable="0" capture="0" action="from qgis.utils import plugins&#xa;plugins['raepa'].run_action(&#xa;    'ouvrage_annuler_derniere_modification',&#xa;    '[% idouvrage %]',&#xa;    '[% @layer_id %]'&#xa;)">
+      <actionScope id="Canvas"/>
+      <actionScope id="Feature"/>
+    </actionsetting>
+  </attributeactions>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>

--- a/raepa/qgis/qml/forms_reparation_AEP.qml
+++ b/raepa/qgis/qml/forms_reparation_AEP.qml
@@ -1,0 +1,383 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Fields|Forms" version="3.10.14-A Coruña">
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="Range">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="AllowNull"/>
+            <Option type="int" value="2147483647" name="Max"/>
+            <Option type="int" value="-2147483648" name="Min"/>
+            <Option type="int" value="0" name="Precision"/>
+            <Option type="int" value="1" name="Step"/>
+            <Option type="QString" value="SpinBox" name="Style"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="idrepar">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="x">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="y">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="supprepare">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="code" name="Key"/>
+            <Option type="QString" value="val_raepa_support_reparation" name="LayerName"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="libelle" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="defreparee">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="code" name="Key"/>
+            <Option type="QString" value="val_raepa_type_defaillance" name="LayerName"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="libelle" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="idsuprepar">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="daterepar">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="allow_null"/>
+            <Option type="bool" value="true" name="calendar_popup"/>
+            <Option type="QString" value="yyyy-MM-dd" name="display_format"/>
+            <Option type="QString" value="yyyy-MM-dd" name="field_format"/>
+            <Option type="bool" value="false" name="field_iso_format"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="mouvrage">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="true" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="nom" name="Key"/>
+            <Option type="QString" value="sys_organisme_gestionnaire" name="LayerName"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="true" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="nom" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_source_historique">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_code_chantier">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_date_import">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias index="0" field="id" name="Identifiant automatique"/>
+    <alias index="1" field="idrepar" name=""/>
+    <alias index="2" field="x" name="X [m]"/>
+    <alias index="3" field="y" name="Y [m]"/>
+    <alias index="4" field="supprepare" name=""/>
+    <alias index="5" field="defreparee" name=""/>
+    <alias index="6" field="idsuprepar" name=""/>
+    <alias index="7" field="daterepar" name=""/>
+    <alias index="8" field="mouvrage" name="Maître d’ouvrage"/>
+    <alias index="9" field="_source_historique" name=""/>
+    <alias index="10" field="_code_chantier" name=""/>
+    <alias index="11" field="_date_import" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default applyOnUpdate="0" expression="" field="id"/>
+    <default applyOnUpdate="0" expression="raepa.generate_oid('raepa_reparaep_p'::text)" field="idrepar"/>
+    <default applyOnUpdate="0" expression="X( $geometry )" field="x"/>
+    <default applyOnUpdate="0" expression="Y( $geometry )" field="y"/>
+    <default applyOnUpdate="0" expression="" field="supprepare"/>
+    <default applyOnUpdate="0" expression="" field="defreparee"/>
+    <default applyOnUpdate="0" expression="'INCONNU'" field="idsuprepar"/>
+    <default applyOnUpdate="0" expression="" field="daterepar"/>
+    <default applyOnUpdate="0" expression="" field="mouvrage"/>
+    <default applyOnUpdate="0" expression="" field="_source_historique"/>
+    <default applyOnUpdate="0" expression="" field="_code_chantier"/>
+    <default applyOnUpdate="0" expression="" field="_date_import"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" exp_strength="0" field="id"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" exp_strength="0" field="idrepar"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" exp_strength="0" field="x"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" exp_strength="0" field="y"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="supprepare"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="defreparee"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="idsuprepar"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="daterepar"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="mouvrage"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_source_historique"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_code_chantier"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_date_import"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" exp="" field="id"/>
+    <constraint desc="" exp="" field="idrepar"/>
+    <constraint desc="" exp="" field="x"/>
+    <constraint desc="" exp="" field="y"/>
+    <constraint desc="" exp="" field="supprepare"/>
+    <constraint desc="" exp="" field="defreparee"/>
+    <constraint desc="" exp="" field="idsuprepar"/>
+    <constraint desc="" exp="" field="daterepar"/>
+    <constraint desc="" exp="" field="mouvrage"/>
+    <constraint desc="" exp="" field="_source_historique"/>
+    <constraint desc="" exp="" field="_code_chantier"/>
+    <constraint desc="" exp="" field="_date_import"/>
+  </constraintExpressions>
+  <expressionfields/>
+  <editform tolerant="1">/../../../.local/share/QGIS/QGIS3/profiles</editform>
+  <editforminit>vw_cover_open</editforminit>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath>/../.local/share/QGIS/.local/share/QGIS/QGIS3/profiles/default/3liz/Reapa</editforminitfilepath>
+  <editforminitcode><![CDATA[from qgepplugin.ui.forms import vw_cover_open
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" columnCount="1" name="Reparation" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Général" visibilityExpressionEnabled="0">
+        <attributeEditorField index="0" showLabel="1" name="id"/>
+        <attributeEditorField index="1" showLabel="1" name="idrepar"/>
+        <attributeEditorField index="5" showLabel="1" name="defreparee"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Technique" visibilityExpressionEnabled="0">
+        <attributeEditorField index="2" showLabel="1" name="x"/>
+        <attributeEditorField index="3" showLabel="1" name="y"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Relations" visibilityExpressionEnabled="0">
+        <attributeEditorField index="4" showLabel="1" name="supprepare"/>
+        <attributeEditorField index="6" showLabel="1" name="idsuprepar"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Historique" visibilityExpressionEnabled="0">
+        <attributeEditorField index="8" showLabel="1" name="mouvrage"/>
+        <attributeEditorField index="7" showLabel="1" name="daterepar"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="_angletampon"/>
+    <field editable="1" name="_capacite"/>
+    <field editable="1" name="_code_chantier"/>
+    <field editable="1" name="_commune"/>
+    <field editable="1" name="_date_import"/>
+    <field editable="1" name="_dateprevue"/>
+    <field editable="1" name="_etatcanalisation"/>
+    <field editable="1" name="_fiche"/>
+    <field editable="1" name="_frequencecuragepreventif"/>
+    <field editable="1" name="_geom_emprise"/>
+    <field editable="1" name="_idinterventionparent"/>
+    <field editable="1" name="_image"/>
+    <field editable="1" name="_nom_appareil"/>
+    <field editable="1" name="_observation"/>
+    <field editable="1" name="_source_historique"/>
+    <field editable="1" name="_temp_data"/>
+    <field editable="1" name="_typeintervention"/>
+    <field editable="1" name="_ztampon"/>
+    <field editable="1" name="andebpose"/>
+    <field editable="1" name="anfinpose"/>
+    <field editable="1" name="dategeoloc"/>
+    <field editable="1" name="datemaj"/>
+    <field editable="1" name="daterepar"/>
+    <field editable="1" name="defreparee"/>
+    <field editable="1" name="fnouvass"/>
+    <field editable="1" name="gexploit"/>
+    <field editable="0" name="id"/>
+    <field editable="1" name="idcanamont"/>
+    <field editable="1" name="idcanaval"/>
+    <field editable="1" name="idcanppale"/>
+    <field editable="1" name="idouvrage"/>
+    <field editable="1" name="idrepar"/>
+    <field editable="1" name="idsuprepar"/>
+    <field editable="1" name="mouvrage"/>
+    <field editable="1" name="qualannee"/>
+    <field editable="1" name="qualglocxy"/>
+    <field editable="1" name="qualglocz"/>
+    <field editable="1" name="sourattrib"/>
+    <field editable="1" name="sourgeoloc"/>
+    <field editable="1" name="sourmaj"/>
+    <field editable="1" name="supprepare"/>
+    <field editable="1" name="typreseau"/>
+    <field editable="1" name="x"/>
+    <field editable="1" name="y"/>
+    <field editable="1" name="z"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="_angletampon"/>
+    <field labelOnTop="0" name="_capacite"/>
+    <field labelOnTop="0" name="_code_chantier"/>
+    <field labelOnTop="0" name="_commune"/>
+    <field labelOnTop="0" name="_date_import"/>
+    <field labelOnTop="0" name="_dateprevue"/>
+    <field labelOnTop="0" name="_etatcanalisation"/>
+    <field labelOnTop="0" name="_fiche"/>
+    <field labelOnTop="0" name="_frequencecuragepreventif"/>
+    <field labelOnTop="0" name="_geom_emprise"/>
+    <field labelOnTop="0" name="_idinterventionparent"/>
+    <field labelOnTop="0" name="_image"/>
+    <field labelOnTop="0" name="_nom_appareil"/>
+    <field labelOnTop="0" name="_observation"/>
+    <field labelOnTop="0" name="_source_historique"/>
+    <field labelOnTop="0" name="_temp_data"/>
+    <field labelOnTop="0" name="_typeintervention"/>
+    <field labelOnTop="0" name="_ztampon"/>
+    <field labelOnTop="0" name="andebpose"/>
+    <field labelOnTop="0" name="anfinpose"/>
+    <field labelOnTop="0" name="dategeoloc"/>
+    <field labelOnTop="0" name="datemaj"/>
+    <field labelOnTop="0" name="daterepar"/>
+    <field labelOnTop="0" name="defreparee"/>
+    <field labelOnTop="0" name="fnouvass"/>
+    <field labelOnTop="0" name="gexploit"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="idcanamont"/>
+    <field labelOnTop="0" name="idcanaval"/>
+    <field labelOnTop="0" name="idcanppale"/>
+    <field labelOnTop="0" name="idouvrage"/>
+    <field labelOnTop="0" name="idrepar"/>
+    <field labelOnTop="0" name="idsuprepar"/>
+    <field labelOnTop="0" name="mouvrage"/>
+    <field labelOnTop="0" name="qualannee"/>
+    <field labelOnTop="0" name="qualglocxy"/>
+    <field labelOnTop="0" name="qualglocz"/>
+    <field labelOnTop="0" name="sourattrib"/>
+    <field labelOnTop="0" name="sourgeoloc"/>
+    <field labelOnTop="0" name="sourmaj"/>
+    <field labelOnTop="0" name="supprepare"/>
+    <field labelOnTop="0" name="typreseau"/>
+    <field labelOnTop="0" name="x"/>
+    <field labelOnTop="0" name="y"/>
+    <field labelOnTop="0" name="z"/>
+  </labelOnTop>
+  <widgets>
+    <widget name="_label_x">
+      <config/>
+    </widget>
+    <widget name="_label_y">
+      <config/>
+    </widget>
+    <widget name="od_file20160921105557083_object_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="re_maintenance_event_wastewater_structure_fk_wastewater_structure_vw_qgep_wastewater_structure_ws_obj_id">
+      <config/>
+    </widget>
+    <widget name="sys_parcours_reseau20171207183948125_idouvrage_raepa_ouvrass_p_geom20171203161907366_idouvrage">
+      <config/>
+    </widget>
+    <widget name="vw_access_aid20150507162234295_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_access_aid_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_backflow_prevention20150531093552085_fk_wastewater_structure_vw_qgep_wastewater_structure_ws_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_backflow_prevention_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_benching20150507162234281_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_benching_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_cover20150507162234308_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_cover____fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_downspout20150507162234268_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_downspout_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_flume20150507162234250_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_flume_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="wastewater_node-fk_wastewater-structure">
+      <config/>
+    </widget>
+  </widgets>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>

--- a/raepa/qgis/qml/forms_reparation_ASS.qml
+++ b/raepa/qgis/qml/forms_reparation_ASS.qml
@@ -1,0 +1,461 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis styleCategories="Fields|Forms" version="3.10.14-A Coruña">
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="Range">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="AllowNull"/>
+            <Option type="int" value="2147483647" name="Max"/>
+            <Option type="int" value="-2147483648" name="Min"/>
+            <Option type="int" value="0" name="Precision"/>
+            <Option type="int" value="1" name="Step"/>
+            <Option type="QString" value="SpinBox" name="Style"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="idrepar">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="x">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="y">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="supprepare">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="code" name="Key"/>
+            <Option type="QString" value="val_raepa_support_reparation" name="LayerName"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="libelle" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="defreparee">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="code" name="Key"/>
+            <Option type="QString" value="val_raepa_type_defaillance" name="LayerName"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="libelle" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="idsuprepar">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="daterepar">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="allow_null"/>
+            <Option type="bool" value="true" name="calendar_popup"/>
+            <Option type="QString" value="yyyy-MM-dd" name="display_format"/>
+            <Option type="QString" value="yyyy-MM-dd" name="field_format"/>
+            <Option type="bool" value="false" name="field_iso_format"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="mouvrage">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="true" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="nom" name="Key"/>
+            <Option type="QString" value="sys_organisme_gestionnaire" name="LayerName"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="true" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="nom" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_typeintervention">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="code" name="Key"/>
+            <Option type="QString" value="_val_raepa_type_intervention_ass" name="LayerName"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="libelle" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_dateprevue">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="allow_null"/>
+            <Option type="bool" value="true" name="calendar_popup"/>
+            <Option type="QString" value="yyyy-MM-dd" name="display_format"/>
+            <Option type="QString" value="yyyy-MM-dd" name="field_format"/>
+            <Option type="bool" value="false" name="field_iso_format"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_etatcanalisation">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_frequencecuragepreventif">
+      <editWidget type="Range">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="AllowNull"/>
+            <Option type="int" value="2147483647" name="Max"/>
+            <Option type="int" value="-2147483648" name="Min"/>
+            <Option type="int" value="0" name="Precision"/>
+            <Option type="int" value="1" name="Step"/>
+            <Option type="QString" value="SpinBox" name="Style"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_idinterventionparent">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_source_historique">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_code_chantier">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias index="0" field="id" name="Identifiant automatique"/>
+    <alias index="1" field="idrepar" name=""/>
+    <alias index="2" field="x" name="X [m]"/>
+    <alias index="3" field="y" name="Y [m]"/>
+    <alias index="4" field="supprepare" name=""/>
+    <alias index="5" field="defreparee" name=""/>
+    <alias index="6" field="idsuprepar" name=""/>
+    <alias index="7" field="daterepar" name=""/>
+    <alias index="8" field="mouvrage" name="Maître d’ouvrage"/>
+    <alias index="9" field="_typeintervention" name=""/>
+    <alias index="10" field="_dateprevue" name=""/>
+    <alias index="11" field="_etatcanalisation" name=""/>
+    <alias index="12" field="_frequencecuragepreventif" name=""/>
+    <alias index="13" field="_idinterventionparent" name=""/>
+    <alias index="14" field="_source_historique" name=""/>
+    <alias index="15" field="_code_chantier" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default applyOnUpdate="0" expression="" field="id"/>
+    <default applyOnUpdate="0" expression="raepa.generate_oid('raepa_reparass_p'::text)" field="idrepar"/>
+    <default applyOnUpdate="0" expression="X( $geometry )" field="x"/>
+    <default applyOnUpdate="0" expression="Y( $geometry )" field="y"/>
+    <default applyOnUpdate="0" expression="" field="supprepare"/>
+    <default applyOnUpdate="0" expression="" field="defreparee"/>
+    <default applyOnUpdate="0" expression="'INCONNU'" field="idsuprepar"/>
+    <default applyOnUpdate="0" expression="" field="daterepar"/>
+    <default applyOnUpdate="0" expression="" field="mouvrage"/>
+    <default applyOnUpdate="0" expression="" field="_typeintervention"/>
+    <default applyOnUpdate="0" expression="" field="_dateprevue"/>
+    <default applyOnUpdate="0" expression="" field="_etatcanalisation"/>
+    <default applyOnUpdate="0" expression="" field="_frequencecuragepreventif"/>
+    <default applyOnUpdate="0" expression="" field="_idinterventionparent"/>
+    <default applyOnUpdate="0" expression="" field="_source_historique"/>
+    <default applyOnUpdate="0" expression="" field="_code_chantier"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" exp_strength="0" field="id"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" exp_strength="0" field="idrepar"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" exp_strength="0" field="x"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" exp_strength="0" field="y"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="supprepare"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="defreparee"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="idsuprepar"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="daterepar"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="mouvrage"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="_typeintervention"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_dateprevue"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_etatcanalisation"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_frequencecuragepreventif"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_idinterventionparent"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_source_historique"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_code_chantier"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" exp="" field="id"/>
+    <constraint desc="" exp="" field="idrepar"/>
+    <constraint desc="" exp="" field="x"/>
+    <constraint desc="" exp="" field="y"/>
+    <constraint desc="" exp="" field="supprepare"/>
+    <constraint desc="" exp="" field="defreparee"/>
+    <constraint desc="" exp="" field="idsuprepar"/>
+    <constraint desc="" exp="" field="daterepar"/>
+    <constraint desc="" exp="" field="mouvrage"/>
+    <constraint desc="" exp="" field="_typeintervention"/>
+    <constraint desc="" exp="" field="_dateprevue"/>
+    <constraint desc="" exp="" field="_etatcanalisation"/>
+    <constraint desc="" exp="" field="_frequencecuragepreventif"/>
+    <constraint desc="" exp="" field="_idinterventionparent"/>
+    <constraint desc="" exp="" field="_source_historique"/>
+    <constraint desc="" exp="" field="_code_chantier"/>
+  </constraintExpressions>
+  <expressionfields/>
+  <editform tolerant="1">/../../../.local/share/QGIS/QGIS3/profiles</editform>
+  <editforminit>vw_cover_open</editforminit>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath>/../.local/share/QGIS/.local/share/QGIS/QGIS3/profiles/default/3liz/Reapa</editforminitfilepath>
+  <editforminitcode><![CDATA[from qgepplugin.ui.forms import vw_cover_open
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" columnCount="1" name="Reparation" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Général" visibilityExpressionEnabled="0">
+        <attributeEditorField index="0" showLabel="1" name="id"/>
+        <attributeEditorField index="1" showLabel="1" name="idrepar"/>
+        <attributeEditorField index="5" showLabel="1" name="defreparee"/>
+        <attributeEditorField index="9" showLabel="1" name="_typeintervention"/>
+        <attributeEditorField index="11" showLabel="1" name="_etatcanalisation"/>
+        <attributeEditorField index="12" showLabel="1" name="_frequencecuragepreventif"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Technique" visibilityExpressionEnabled="0">
+        <attributeEditorField index="2" showLabel="1" name="x"/>
+        <attributeEditorField index="3" showLabel="1" name="y"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Relations" visibilityExpressionEnabled="0">
+        <attributeEditorField index="4" showLabel="1" name="supprepare"/>
+        <attributeEditorField index="6" showLabel="1" name="idsuprepar"/>
+        <attributeEditorField index="13" showLabel="1" name="_idinterventionparent"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Historique" visibilityExpressionEnabled="0">
+        <attributeEditorField index="8" showLabel="1" name="mouvrage"/>
+        <attributeEditorField index="7" showLabel="1" name="daterepar"/>
+        <attributeEditorField index="10" showLabel="1" name="_dateprevue"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="_angletampon"/>
+    <field editable="1" name="_capacite"/>
+    <field editable="1" name="_code_chantier"/>
+    <field editable="1" name="_commune"/>
+    <field editable="1" name="_date_import"/>
+    <field editable="1" name="_dateprevue"/>
+    <field editable="1" name="_etatcanalisation"/>
+    <field editable="1" name="_fiche"/>
+    <field editable="1" name="_frequencecuragepreventif"/>
+    <field editable="1" name="_geom_emprise"/>
+    <field editable="1" name="_idinterventionparent"/>
+    <field editable="1" name="_image"/>
+    <field editable="1" name="_nom_appareil"/>
+    <field editable="1" name="_observation"/>
+    <field editable="1" name="_source_historique"/>
+    <field editable="1" name="_temp_data"/>
+    <field editable="1" name="_typeintervention"/>
+    <field editable="1" name="_ztampon"/>
+    <field editable="1" name="andebpose"/>
+    <field editable="1" name="anfinpose"/>
+    <field editable="1" name="dategeoloc"/>
+    <field editable="1" name="datemaj"/>
+    <field editable="1" name="daterepar"/>
+    <field editable="1" name="defreparee"/>
+    <field editable="1" name="fnouvass"/>
+    <field editable="1" name="gexploit"/>
+    <field editable="0" name="id"/>
+    <field editable="1" name="idcanamont"/>
+    <field editable="1" name="idcanaval"/>
+    <field editable="1" name="idcanppale"/>
+    <field editable="1" name="idouvrage"/>
+    <field editable="1" name="idrepar"/>
+    <field editable="1" name="idsuprepar"/>
+    <field editable="1" name="mouvrage"/>
+    <field editable="1" name="qualannee"/>
+    <field editable="1" name="qualglocxy"/>
+    <field editable="1" name="qualglocz"/>
+    <field editable="1" name="sourattrib"/>
+    <field editable="1" name="sourgeoloc"/>
+    <field editable="1" name="sourmaj"/>
+    <field editable="1" name="supprepare"/>
+    <field editable="1" name="typreseau"/>
+    <field editable="1" name="x"/>
+    <field editable="1" name="y"/>
+    <field editable="1" name="z"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="_angletampon"/>
+    <field labelOnTop="0" name="_capacite"/>
+    <field labelOnTop="0" name="_code_chantier"/>
+    <field labelOnTop="0" name="_commune"/>
+    <field labelOnTop="0" name="_date_import"/>
+    <field labelOnTop="0" name="_dateprevue"/>
+    <field labelOnTop="0" name="_etatcanalisation"/>
+    <field labelOnTop="0" name="_fiche"/>
+    <field labelOnTop="0" name="_frequencecuragepreventif"/>
+    <field labelOnTop="0" name="_geom_emprise"/>
+    <field labelOnTop="0" name="_idinterventionparent"/>
+    <field labelOnTop="0" name="_image"/>
+    <field labelOnTop="0" name="_nom_appareil"/>
+    <field labelOnTop="0" name="_observation"/>
+    <field labelOnTop="0" name="_source_historique"/>
+    <field labelOnTop="0" name="_temp_data"/>
+    <field labelOnTop="0" name="_typeintervention"/>
+    <field labelOnTop="0" name="_ztampon"/>
+    <field labelOnTop="0" name="andebpose"/>
+    <field labelOnTop="0" name="anfinpose"/>
+    <field labelOnTop="0" name="dategeoloc"/>
+    <field labelOnTop="0" name="datemaj"/>
+    <field labelOnTop="0" name="daterepar"/>
+    <field labelOnTop="0" name="defreparee"/>
+    <field labelOnTop="0" name="fnouvass"/>
+    <field labelOnTop="0" name="gexploit"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="idcanamont"/>
+    <field labelOnTop="0" name="idcanaval"/>
+    <field labelOnTop="0" name="idcanppale"/>
+    <field labelOnTop="0" name="idouvrage"/>
+    <field labelOnTop="0" name="idrepar"/>
+    <field labelOnTop="0" name="idsuprepar"/>
+    <field labelOnTop="0" name="mouvrage"/>
+    <field labelOnTop="0" name="qualannee"/>
+    <field labelOnTop="0" name="qualglocxy"/>
+    <field labelOnTop="0" name="qualglocz"/>
+    <field labelOnTop="0" name="sourattrib"/>
+    <field labelOnTop="0" name="sourgeoloc"/>
+    <field labelOnTop="0" name="sourmaj"/>
+    <field labelOnTop="0" name="supprepare"/>
+    <field labelOnTop="0" name="typreseau"/>
+    <field labelOnTop="0" name="x"/>
+    <field labelOnTop="0" name="y"/>
+    <field labelOnTop="0" name="z"/>
+  </labelOnTop>
+  <widgets>
+    <widget name="_label_x">
+      <config/>
+    </widget>
+    <widget name="_label_y">
+      <config/>
+    </widget>
+    <widget name="od_file20160921105557083_object_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="re_maintenance_event_wastewater_structure_fk_wastewater_structure_vw_qgep_wastewater_structure_ws_obj_id">
+      <config/>
+    </widget>
+    <widget name="sys_parcours_reseau20171207183948125_idouvrage_raepa_ouvrass_p_geom20171203161907366_idouvrage">
+      <config/>
+    </widget>
+    <widget name="vw_access_aid20150507162234295_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_access_aid_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_backflow_prevention20150531093552085_fk_wastewater_structure_vw_qgep_wastewater_structure_ws_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_backflow_prevention_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_benching20150507162234281_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_benching_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_cover20150507162234308_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_cover____fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_downspout20150507162234268_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_downspout_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_flume20150507162234250_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_flume_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="wastewater_node-fk_wastewater-structure">
+      <config/>
+    </widget>
+  </widgets>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>

--- a/raepa/qgis/qml/reparation_AEP.qml
+++ b/raepa/qgis/qml/reparation_AEP.qml
@@ -1,0 +1,807 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis hasScaleBasedVisibilityFlag="1" styleCategories="AllStyleCategories" minScale="2501" labelsEnabled="0" simplifyAlgorithm="0" simplifyDrawingHints="0" simplifyLocal="0" readOnly="0" version="3.10.14-A Coruña" maxScale="1" simplifyDrawingTol="1" simplifyMaxScale="1">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 type="RuleRenderer" enableorderby="0" symbollevels="0" forceraster="0">
+    <rules key="{6736e613-3750-466f-8a9f-3310fefc92b3}">
+      <rule label="Autre" key="{b56796d8-f43d-4594-9034-e3b57e012d40}" symbol="0" filter="ELSE"/>
+      <rule label="Indeterminée" key="{b91bd35f-ad4f-4867-858e-2468cc653655}" symbol="1" filter="&quot;defreparee&quot; = '00'"/>
+      <rule label="Casse longitudinale" key="{8ea5d954-936e-45b8-b312-69c24af40e58}" symbol="2" filter="&quot;defreparee&quot; = '01'"/>
+      <rule label="Casse nette" key="{0040e9ed-37d4-43f8-9f52-bb2ce2299680}" symbol="3" filter="&quot;defreparee&quot; = '02'"/>
+      <rule label="Déboitement" key="{c11c4de7-b7db-400c-bfce-7c450065efa2}" symbol="4" filter="&quot;defreparee&quot; = '03'"/>
+      <rule label="Fissure" key="{4668a609-4391-4a15-b2d7-a825dc1d478b}" symbol="5" filter="&quot;defreparee&quot; = '04'"/>
+      <rule label="Joint" key="{5887fd95-52be-4a0a-8f00-fbd41c415dd1}" symbol="6" filter="&quot;defreparee&quot; = '05'"/>
+      <rule label="Percement" key="{e5e92216-7a8f-4ba4-be8f-31ec92f3e543}" symbol="7" filter="&quot;defreparee&quot; = '06'"/>
+    </rules>
+    <symbols>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="0">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="0,0,0,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="cross_fill" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="0,0,0,255" k="outline_color"/>
+          <prop v="no" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="area" k="scale_method"/>
+          <prop v="0.4" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="1">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="61,209,231,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="2">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="213,180,60,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="3">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="114,155,111,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="4">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="0,0,0,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="5">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="141,90,153,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="6">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="31,93,219,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="7">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="183,1,1,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <effect enabled="0" type="effectStack">
+      <effect type="drawSource">
+        <prop v="0" k="blend_mode"/>
+        <prop v="2" k="draw_mode"/>
+        <prop v="1" k="enabled"/>
+        <prop v="1" k="opacity"/>
+      </effect>
+    </effect>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style textOpacity="1" isExpression="1" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" fontWeight="50" multilineHeight="1" fontLetterSpacing="0" fontKerning="1" namedStyle="Normal" fontStrikeout="0" fontFamily="MS Shell Dlg 2" fieldName="concat(&#xa;&#x9;coalesce('TN ' || round(&quot;_ztampon&quot;, 2), ''),&#xa;&#x9;'@',&#xa;&#x9;coalesce('RD ' || round(&quot;z&quot;, 2), '')&#xa;)&#xa;&#xa;" fontWordSpacing="0" blendMode="0" fontSize="7" fontSizeUnit="Point" useSubstitutions="0" fontItalic="0" textColor="0,0,0,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontUnderline="0" fontCapitals="0">
+        <text-buffer bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferBlendMode="0" bufferDraw="1" bufferColor="255,255,255,255" bufferNoFill="0" bufferSizeUnits="MM" bufferJoinStyle="64"/>
+        <background shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderWidth="0" shapeJoinStyle="64" shapeRotation="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBlendMode="0" shapeOffsetY="0" shapeSizeType="0" shapeRadiiY="0" shapeDraw="0" shapeBorderWidthUnit="MM" shapeBorderColor="128,128,128,255" shapeOpacity="1" shapeType="0" shapeSizeX="0" shapeOffsetX="0" shapeSizeY="0">
+          <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="markerSymbol">
+            <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+              <prop v="0" k="angle"/>
+              <prop v="133,182,111,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="diameter" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowOffsetGlobal="1" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowOffsetAngle="135" shadowBlendMode="6" shadowDraw="0" shadowOpacity="0.7" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowOffsetUnit="MM" shadowOffsetDist="1" shadowUnder="0" shadowRadiusUnit="MM"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format useMaxLineLengthForAutoWrap="1" multilineAlign="1" placeDirectionSymbol="0" decimals="3" addDirectionSymbol="0" leftDirectionSymbol="&lt;" reverseDirectionSymbol="0" formatNumbers="0" plussign="0" wrapChar="@" rightDirectionSymbol=">" autoWrapLength="0"/>
+      <placement maxCurvedCharAngleIn="20" maxCurvedCharAngleOut="-20" layerType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" yOffset="0" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" geometryGeneratorEnabled="0" placement="0" repeatDistanceUnits="MM" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGenerator="" offsetUnits="MapUnit" repeatDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" dist="3" distUnits="MM" rotationAngle="0" centroidWhole="0" preserveRotation="1" fitInPolygonOnly="0" priority="10" overrunDistance="0" overrunDistanceUnit="MM" centroidInside="0" offsetType="0" placementFlags="0"/>
+      <rendering scaleMin="1" scaleVisibility="0" minFeatureSize="0" fontMaxPixelSize="10000" mergeLines="0" drawLabels="1" displayAll="1" obstacle="1" scaleMax="5000" limitNumLabels="0" fontLimitPixelSize="0" labelPerPart="0" zIndex="0" obstacleFactor="1.4" upsidedownLabels="0" obstacleType="0" fontMinPixelSize="3" maxNumLabels="2000"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option type="Map" name="properties">
+            <Option type="Map" name="AlwaysShow">
+              <Option type="bool" value="true" name="active"/>
+              <Option type="QString" value="&quot;fnouvass&quot;  IN ('07','_3', '04', '06', '_7') AND &quot;_source_historique&quot; != 'si2g'" name="expression"/>
+              <Option type="int" value="3" name="type"/>
+            </Option>
+            <Option type="Map" name="Color">
+              <Option type="bool" value="true" name="active"/>
+              <Option type="QString" value="CASE &#xa;&#x9;WHEN typreseau IN ('01') THEN '50,160,45,255' &#xa;&#x9;WHEN typreseau IN ('02') THEN '255,0,0,255' &#xa;&#x9;WHEN typreseau IN ('03') THEN '140,70,0,255' &#xa;&#x9;ELSE '161,161,161,255' &#xa;END" name="expression"/>
+              <Option type="int" value="3" name="type"/>
+            </Option>
+            <Option type="Map" name="Show">
+              <Option type="bool" value="true" name="active"/>
+              <Option type="QString" value="&quot;_source_historique&quot; != 'si2g' OR &quot;_source_historique&quot; IS NULL" name="expression"/>
+              <Option type="int" value="3" name="type"/>
+            </Option>
+          </Option>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+          <Option type="Map" name="ddProperties">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+          <Option type="bool" value="false" name="drawToAllParts"/>
+          <Option type="QString" value="0" name="enabled"/>
+          <Option type="QString" value="&lt;symbol alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; type=&quot;line&quot; force_rhr=&quot;0&quot; name=&quot;symbol&quot;>&lt;layer enabled=&quot;1&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+          <Option type="double" value="0" name="minLength"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+          <Option type="QString" value="MM" name="minLengthUnit"/>
+          <Option type="double" value="0" name="offsetFromAnchor"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+          <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+          <Option type="double" value="0" name="offsetFromLabel"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+          <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
+  <customproperties>
+    <property key="dualview/previewExpressions" value="&quot;id&quot;"/>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory scaleBasedVisibility="1" labelPlacementMethod="XHeight" enabled="0" scaleDependency="Area" sizeScale="3x:0,0,0,0,0,0" rotationOffset="270" penAlpha="255" minimumSize="0" width="15" height="15" backgroundColor="#ffffff" opacity="1" lineSizeType="MM" diagramOrientation="Up" barWidth="5" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="1" maxScaleDenominator="2501" backgroundAlpha="255" sizeType="MM" penWidth="0" penColor="#000000">
+      <fontProperties style="" description="Ubuntu,11,-1,5,50,0,0,0,0,0"/>
+      <attribute label="" color="#000000" field=""/>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings placement="0" linePlacementFlags="18" priority="0" showAll="1" zIndex="0" dist="0" obstacle="0">
+    <properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="Range">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="AllowNull"/>
+            <Option type="int" value="2147483647" name="Max"/>
+            <Option type="int" value="-2147483648" name="Min"/>
+            <Option type="int" value="0" name="Precision"/>
+            <Option type="int" value="1" name="Step"/>
+            <Option type="QString" value="SpinBox" name="Style"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="idrepar">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="x">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="y">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="supprepare">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="code" name="Key"/>
+            <Option type="QString" value="val_raepa_support_reparation_2dd4cb7f_3902_44ec_b6d1_ad3ab46481db" name="Layer"/>
+            <Option type="QString" value="val_raepa_support_reparation" name="LayerName"/>
+            <Option type="QString" value="postgres" name="LayerProviderName"/>
+            <Option type="QString" value="dbname='postgres' host=localhost port=5432 user='postgres' key='code' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;raepa&quot;.&quot;val_raepa_support_reparation&quot; sql=" name="LayerSource"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="libelle" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="defreparee">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="code" name="Key"/>
+            <Option type="QString" value="val_raepa_type_defaillance_e017b148_a5df_43e0_b243_de803b1f968d" name="Layer"/>
+            <Option type="QString" value="val_raepa_type_defaillance" name="LayerName"/>
+            <Option type="QString" value="postgres" name="LayerProviderName"/>
+            <Option type="QString" value="dbname='postgres' host=localhost port=5432 user='postgres' key='code' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;raepa&quot;.&quot;val_raepa_type_defaillance&quot; sql=" name="LayerSource"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="libelle" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="idsuprepar">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="daterepar">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="allow_null"/>
+            <Option type="bool" value="true" name="calendar_popup"/>
+            <Option type="QString" value="yyyy-MM-dd" name="display_format"/>
+            <Option type="QString" value="yyyy-MM-dd" name="field_format"/>
+            <Option type="bool" value="false" name="field_iso_format"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="mouvrage">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="true" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="nom" name="Key"/>
+            <Option type="QString" value="sys_organisme_gestionnaire" name="LayerName"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="true" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="nom" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_source_historique">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_code_chantier">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_date_import">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias index="0" field="id" name="Identifiant automatique"/>
+    <alias index="1" field="idrepar" name=""/>
+    <alias index="2" field="x" name="X [m]"/>
+    <alias index="3" field="y" name="Y [m]"/>
+    <alias index="4" field="supprepare" name=""/>
+    <alias index="5" field="defreparee" name=""/>
+    <alias index="6" field="idsuprepar" name=""/>
+    <alias index="7" field="daterepar" name=""/>
+    <alias index="8" field="mouvrage" name="Maître d’ouvrage"/>
+    <alias index="9" field="_source_historique" name=""/>
+    <alias index="10" field="_code_chantier" name=""/>
+    <alias index="11" field="_date_import" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default applyOnUpdate="0" expression="" field="id"/>
+    <default applyOnUpdate="0" expression="raepa.generate_oid('raepa_reparaep_p'::text)" field="idrepar"/>
+    <default applyOnUpdate="0" expression="X( $geometry )" field="x"/>
+    <default applyOnUpdate="0" expression="Y( $geometry )" field="y"/>
+    <default applyOnUpdate="0" expression="" field="supprepare"/>
+    <default applyOnUpdate="0" expression="" field="defreparee"/>
+    <default applyOnUpdate="0" expression="'INCONNU'" field="idsuprepar"/>
+    <default applyOnUpdate="0" expression="" field="daterepar"/>
+    <default applyOnUpdate="0" expression="" field="mouvrage"/>
+    <default applyOnUpdate="0" expression="" field="_source_historique"/>
+    <default applyOnUpdate="0" expression="" field="_code_chantier"/>
+    <default applyOnUpdate="0" expression="" field="_date_import"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" exp_strength="0" field="id"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" exp_strength="0" field="idrepar"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" exp_strength="0" field="x"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" exp_strength="0" field="y"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="supprepare"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="defreparee"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="idsuprepar"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="daterepar"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="mouvrage"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_source_historique"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_code_chantier"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_date_import"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" exp="" field="id"/>
+    <constraint desc="" exp="" field="idrepar"/>
+    <constraint desc="" exp="" field="x"/>
+    <constraint desc="" exp="" field="y"/>
+    <constraint desc="" exp="" field="supprepare"/>
+    <constraint desc="" exp="" field="defreparee"/>
+    <constraint desc="" exp="" field="idsuprepar"/>
+    <constraint desc="" exp="" field="daterepar"/>
+    <constraint desc="" exp="" field="mouvrage"/>
+    <constraint desc="" exp="" field="_source_historique"/>
+    <constraint desc="" exp="" field="_code_chantier"/>
+    <constraint desc="" exp="" field="_date_import"/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <actionsetting shortTitle="" icon="" type="1" id="{da93bab3-994c-46ba-8a60-e26250a6b93e}" action="from qgis.utils import plugins&#xa;plugins['raepa'].run_action(&#xa;    'parcourir_reseau_depuis_cet_objet',&#xa;    '[% idouvrage %]',&#xa;    0&#xa;)" capture="0" notificationMessage="" name="Parcourir le réseau depuis cet objet" isEnabledOnlyWhenEditable="0">
+      <actionScope id="Feature"/>
+      <actionScope id="Field"/>
+      <actionScope id="Canvas"/>
+    </actionsetting>
+    <actionsetting shortTitle="" icon="" type="1" id="{df63f66d-97f0-4a00-b447-de1a30cc7cf5}" action="from qgis.utils import plugins&#xa;plugins['raepa'].run_action(&#xa;    'ouvrage_annuler_derniere_modification',&#xa;    '[% idouvrage %]',&#xa;    '[% @layer_id %]'&#xa;)" capture="0" notificationMessage="" name="Annuler la dernière modification" isEnabledOnlyWhenEditable="0">
+      <actionScope id="Feature"/>
+      <actionScope id="Canvas"/>
+    </actionsetting>
+  </attributeactions>
+  <attributetableconfig sortExpression="&quot;idouvrage&quot;" actionWidgetStyle="dropDown" sortOrder="1">
+    <columns>
+      <column width="242" type="actions" hidden="0"/>
+      <column width="-1" type="field" hidden="1" name="x"/>
+      <column width="-1" type="field" hidden="1" name="y"/>
+      <column width="-1" type="field" hidden="1" name="mouvrage"/>
+      <column width="-1" type="field" hidden="0" name="id"/>
+      <column width="-1" type="field" hidden="0" name="idrepar"/>
+      <column width="-1" type="field" hidden="0" name="supprepare"/>
+      <column width="-1" type="field" hidden="0" name="defreparee"/>
+      <column width="-1" type="field" hidden="0" name="idsuprepar"/>
+      <column width="-1" type="field" hidden="0" name="daterepar"/>
+      <column width="-1" type="field" hidden="0" name="_source_historique"/>
+      <column width="-1" type="field" hidden="0" name="_code_chantier"/>
+      <column width="-1" type="field" hidden="0" name="_date_import"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1">/../../../.local/share/QGIS/QGIS3/profiles</editform>
+  <editforminit>vw_cover_open</editforminit>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath>/../.local/share/QGIS/.local/share/QGIS/QGIS3/profiles/default/3liz/Reapa</editforminitfilepath>
+  <editforminitcode><![CDATA[from qgepplugin.ui.forms import vw_cover_open
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" columnCount="1" name="Reparation" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Général" visibilityExpressionEnabled="0">
+        <attributeEditorField index="0" showLabel="1" name="id"/>
+        <attributeEditorField index="1" showLabel="1" name="idrepar"/>
+        <attributeEditorField index="5" showLabel="1" name="defreparee"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Technique" visibilityExpressionEnabled="0">
+        <attributeEditorField index="2" showLabel="1" name="x"/>
+        <attributeEditorField index="3" showLabel="1" name="y"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Relations" visibilityExpressionEnabled="0">
+        <attributeEditorField index="4" showLabel="1" name="supprepare"/>
+        <attributeEditorField index="6" showLabel="1" name="idsuprepar"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Historique" visibilityExpressionEnabled="0">
+        <attributeEditorField index="8" showLabel="1" name="mouvrage"/>
+        <attributeEditorField index="7" showLabel="1" name="daterepar"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="_angletampon"/>
+    <field editable="1" name="_capacite"/>
+    <field editable="1" name="_code_chantier"/>
+    <field editable="1" name="_commune"/>
+    <field editable="1" name="_date_import"/>
+    <field editable="1" name="_dateprevue"/>
+    <field editable="1" name="_etatcanalisation"/>
+    <field editable="1" name="_fiche"/>
+    <field editable="1" name="_frequencecuragepreventif"/>
+    <field editable="1" name="_geom_emprise"/>
+    <field editable="1" name="_idinterventionparent"/>
+    <field editable="1" name="_image"/>
+    <field editable="1" name="_nom_appareil"/>
+    <field editable="1" name="_observation"/>
+    <field editable="1" name="_source_historique"/>
+    <field editable="1" name="_temp_data"/>
+    <field editable="1" name="_typeintervention"/>
+    <field editable="1" name="_ztampon"/>
+    <field editable="1" name="andebpose"/>
+    <field editable="1" name="anfinpose"/>
+    <field editable="1" name="dategeoloc"/>
+    <field editable="1" name="datemaj"/>
+    <field editable="1" name="daterepar"/>
+    <field editable="1" name="defreparee"/>
+    <field editable="1" name="fnouvass"/>
+    <field editable="1" name="gexploit"/>
+    <field editable="0" name="id"/>
+    <field editable="1" name="idcanamont"/>
+    <field editable="1" name="idcanaval"/>
+    <field editable="1" name="idcanppale"/>
+    <field editable="1" name="idouvrage"/>
+    <field editable="1" name="idrepar"/>
+    <field editable="1" name="idsuprepar"/>
+    <field editable="1" name="mouvrage"/>
+    <field editable="1" name="qualannee"/>
+    <field editable="1" name="qualglocxy"/>
+    <field editable="1" name="qualglocz"/>
+    <field editable="1" name="sourattrib"/>
+    <field editable="1" name="sourgeoloc"/>
+    <field editable="1" name="sourmaj"/>
+    <field editable="1" name="supprepare"/>
+    <field editable="1" name="typreseau"/>
+    <field editable="1" name="x"/>
+    <field editable="1" name="y"/>
+    <field editable="1" name="z"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="_angletampon"/>
+    <field labelOnTop="0" name="_capacite"/>
+    <field labelOnTop="0" name="_code_chantier"/>
+    <field labelOnTop="0" name="_commune"/>
+    <field labelOnTop="0" name="_date_import"/>
+    <field labelOnTop="0" name="_dateprevue"/>
+    <field labelOnTop="0" name="_etatcanalisation"/>
+    <field labelOnTop="0" name="_fiche"/>
+    <field labelOnTop="0" name="_frequencecuragepreventif"/>
+    <field labelOnTop="0" name="_geom_emprise"/>
+    <field labelOnTop="0" name="_idinterventionparent"/>
+    <field labelOnTop="0" name="_image"/>
+    <field labelOnTop="0" name="_nom_appareil"/>
+    <field labelOnTop="0" name="_observation"/>
+    <field labelOnTop="0" name="_source_historique"/>
+    <field labelOnTop="0" name="_temp_data"/>
+    <field labelOnTop="0" name="_typeintervention"/>
+    <field labelOnTop="0" name="_ztampon"/>
+    <field labelOnTop="0" name="andebpose"/>
+    <field labelOnTop="0" name="anfinpose"/>
+    <field labelOnTop="0" name="dategeoloc"/>
+    <field labelOnTop="0" name="datemaj"/>
+    <field labelOnTop="0" name="daterepar"/>
+    <field labelOnTop="0" name="defreparee"/>
+    <field labelOnTop="0" name="fnouvass"/>
+    <field labelOnTop="0" name="gexploit"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="idcanamont"/>
+    <field labelOnTop="0" name="idcanaval"/>
+    <field labelOnTop="0" name="idcanppale"/>
+    <field labelOnTop="0" name="idouvrage"/>
+    <field labelOnTop="0" name="idrepar"/>
+    <field labelOnTop="0" name="idsuprepar"/>
+    <field labelOnTop="0" name="mouvrage"/>
+    <field labelOnTop="0" name="qualannee"/>
+    <field labelOnTop="0" name="qualglocxy"/>
+    <field labelOnTop="0" name="qualglocz"/>
+    <field labelOnTop="0" name="sourattrib"/>
+    <field labelOnTop="0" name="sourgeoloc"/>
+    <field labelOnTop="0" name="sourmaj"/>
+    <field labelOnTop="0" name="supprepare"/>
+    <field labelOnTop="0" name="typreseau"/>
+    <field labelOnTop="0" name="x"/>
+    <field labelOnTop="0" name="y"/>
+    <field labelOnTop="0" name="z"/>
+  </labelOnTop>
+  <widgets>
+    <widget name="_label_x">
+      <config/>
+    </widget>
+    <widget name="_label_y">
+      <config/>
+    </widget>
+    <widget name="od_file20160921105557083_object_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="re_maintenance_event_wastewater_structure_fk_wastewater_structure_vw_qgep_wastewater_structure_ws_obj_id">
+      <config/>
+    </widget>
+    <widget name="sys_parcours_reseau20171207183948125_idouvrage_raepa_ouvrass_p_geom20171203161907366_idouvrage">
+      <config/>
+    </widget>
+    <widget name="vw_access_aid20150507162234295_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_access_aid_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_backflow_prevention20150531093552085_fk_wastewater_structure_vw_qgep_wastewater_structure_ws_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_backflow_prevention_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_benching20150507162234281_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_benching_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_cover20150507162234308_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_cover____fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_downspout20150507162234268_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_downspout_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_flume20150507162234250_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_flume_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="wastewater_node-fk_wastewater-structure">
+      <config/>
+    </widget>
+  </widgets>
+  <previewExpression>"id"</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>

--- a/raepa/qgis/qml/reparation_ASS.qml
+++ b/raepa/qgis/qml/reparation_ASS.qml
@@ -1,0 +1,886 @@
+<!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
+<qgis hasScaleBasedVisibilityFlag="1" styleCategories="AllStyleCategories" minScale="2501" labelsEnabled="0" simplifyAlgorithm="0" simplifyDrawingHints="0" simplifyLocal="0" readOnly="0" version="3.10.14-A Coruña" maxScale="1" simplifyDrawingTol="1" simplifyMaxScale="1">
+  <flags>
+    <Identifiable>1</Identifiable>
+    <Removable>1</Removable>
+    <Searchable>1</Searchable>
+  </flags>
+  <renderer-v2 type="RuleRenderer" enableorderby="0" symbollevels="0" forceraster="0">
+    <rules key="{6736e613-3750-466f-8a9f-3310fefc92b3}">
+      <rule label="Autre" key="{b56796d8-f43d-4594-9034-e3b57e012d40}" symbol="0" filter="ELSE"/>
+      <rule label="Indeterminée" key="{b91bd35f-ad4f-4867-858e-2468cc653655}" symbol="1" filter="&quot;defreparee&quot; = '00'"/>
+      <rule label="Casse longitudinale" key="{8ea5d954-936e-45b8-b312-69c24af40e58}" symbol="2" filter="&quot;defreparee&quot; = '01'"/>
+      <rule label="Casse nette" key="{0040e9ed-37d4-43f8-9f52-bb2ce2299680}" symbol="3" filter="&quot;defreparee&quot; = '02'"/>
+      <rule label="Déboitement" key="{c11c4de7-b7db-400c-bfce-7c450065efa2}" symbol="4" filter="&quot;defreparee&quot; = '03'"/>
+      <rule label="Fissure" key="{4668a609-4391-4a15-b2d7-a825dc1d478b}" symbol="5" filter="&quot;defreparee&quot; = '04'"/>
+      <rule label="Joint" key="{5887fd95-52be-4a0a-8f00-fbd41c415dd1}" symbol="6" filter="&quot;defreparee&quot; = '05'"/>
+      <rule label="Percement" key="{e5e92216-7a8f-4ba4-be8f-31ec92f3e543}" symbol="7" filter="&quot;defreparee&quot; = '06'"/>
+    </rules>
+    <symbols>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="0">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="0,0,0,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="cross_fill" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="0,0,0,255" k="outline_color"/>
+          <prop v="no" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="area" k="scale_method"/>
+          <prop v="0.4" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="1">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="61,209,231,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="2">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="213,180,60,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="3">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="114,155,111,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="4">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="0,0,0,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="5">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="141,90,153,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="6">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="31,93,219,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+      <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="7">
+        <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+          <prop v="0" k="angle"/>
+          <prop v="183,1,1,255" k="color"/>
+          <prop v="1" k="horizontal_anchor_point"/>
+          <prop v="bevel" k="joinstyle"/>
+          <prop v="triangle" k="name"/>
+          <prop v="0,0" k="offset"/>
+          <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+          <prop v="MapUnit" k="offset_unit"/>
+          <prop v="35,35,35,255" k="outline_color"/>
+          <prop v="solid" k="outline_style"/>
+          <prop v="0" k="outline_width"/>
+          <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+          <prop v="MapUnit" k="outline_width_unit"/>
+          <prop v="diameter" k="scale_method"/>
+          <prop v="0.6" k="size"/>
+          <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+          <prop v="MapUnit" k="size_unit"/>
+          <prop v="1" k="vertical_anchor_point"/>
+          <data_defined_properties>
+            <Option type="Map">
+              <Option type="QString" value="" name="name"/>
+              <Option name="properties"/>
+              <Option type="QString" value="collection" name="type"/>
+            </Option>
+          </data_defined_properties>
+        </layer>
+      </symbol>
+    </symbols>
+    <effect enabled="0" type="effectStack">
+      <effect type="drawSource">
+        <prop v="0" k="blend_mode"/>
+        <prop v="2" k="draw_mode"/>
+        <prop v="1" k="enabled"/>
+        <prop v="1" k="opacity"/>
+      </effect>
+    </effect>
+  </renderer-v2>
+  <labeling type="simple">
+    <settings calloutType="simple">
+      <text-style textOpacity="1" isExpression="1" previewBkgrdColor="255,255,255,255" textOrientation="horizontal" fontWeight="50" multilineHeight="1" fontLetterSpacing="0" fontKerning="1" namedStyle="Normal" fontStrikeout="0" fontFamily="MS Shell Dlg 2" fieldName="concat(&#xa;&#x9;coalesce('TN ' || round(&quot;_ztampon&quot;, 2), ''),&#xa;&#x9;'@',&#xa;&#x9;coalesce('RD ' || round(&quot;z&quot;, 2), '')&#xa;)&#xa;&#xa;" fontWordSpacing="0" blendMode="0" fontSize="7" fontSizeUnit="Point" useSubstitutions="0" fontItalic="0" textColor="0,0,0,255" fontSizeMapUnitScale="3x:0,0,0,0,0,0" fontUnderline="0" fontCapitals="0">
+        <text-buffer bufferOpacity="1" bufferSize="1" bufferSizeMapUnitScale="3x:0,0,0,0,0,0" bufferBlendMode="0" bufferDraw="1" bufferColor="255,255,255,255" bufferNoFill="0" bufferSizeUnits="MM" bufferJoinStyle="64"/>
+        <background shapeBorderWidthMapUnitScale="3x:0,0,0,0,0,0" shapeOffsetUnit="MM" shapeRotationType="0" shapeRadiiMapUnitScale="3x:0,0,0,0,0,0" shapeFillColor="255,255,255,255" shapeSizeMapUnitScale="3x:0,0,0,0,0,0" shapeRadiiX="0" shapeSVGFile="" shapeRadiiUnit="MM" shapeBorderWidth="0" shapeJoinStyle="64" shapeRotation="0" shapeOffsetMapUnitScale="3x:0,0,0,0,0,0" shapeSizeUnit="MM" shapeBlendMode="0" shapeOffsetY="0" shapeSizeType="0" shapeRadiiY="0" shapeDraw="0" shapeBorderWidthUnit="MM" shapeBorderColor="128,128,128,255" shapeOpacity="1" shapeType="0" shapeSizeX="0" shapeOffsetX="0" shapeSizeY="0">
+          <symbol alpha="1" clip_to_extent="1" type="marker" force_rhr="0" name="markerSymbol">
+            <layer enabled="1" class="SimpleMarker" locked="0" pass="0">
+              <prop v="0" k="angle"/>
+              <prop v="133,182,111,255" k="color"/>
+              <prop v="1" k="horizontal_anchor_point"/>
+              <prop v="bevel" k="joinstyle"/>
+              <prop v="circle" k="name"/>
+              <prop v="0,0" k="offset"/>
+              <prop v="3x:0,0,0,0,0,0" k="offset_map_unit_scale"/>
+              <prop v="MM" k="offset_unit"/>
+              <prop v="35,35,35,255" k="outline_color"/>
+              <prop v="solid" k="outline_style"/>
+              <prop v="0" k="outline_width"/>
+              <prop v="3x:0,0,0,0,0,0" k="outline_width_map_unit_scale"/>
+              <prop v="MM" k="outline_width_unit"/>
+              <prop v="diameter" k="scale_method"/>
+              <prop v="2" k="size"/>
+              <prop v="3x:0,0,0,0,0,0" k="size_map_unit_scale"/>
+              <prop v="MM" k="size_unit"/>
+              <prop v="1" k="vertical_anchor_point"/>
+              <data_defined_properties>
+                <Option type="Map">
+                  <Option type="QString" value="" name="name"/>
+                  <Option name="properties"/>
+                  <Option type="QString" value="collection" name="type"/>
+                </Option>
+              </data_defined_properties>
+            </layer>
+          </symbol>
+        </background>
+        <shadow shadowOffsetGlobal="1" shadowColor="0,0,0,255" shadowOffsetMapUnitScale="3x:0,0,0,0,0,0" shadowRadiusMapUnitScale="3x:0,0,0,0,0,0" shadowScale="100" shadowOffsetAngle="135" shadowBlendMode="6" shadowDraw="0" shadowOpacity="0.7" shadowRadius="1.5" shadowRadiusAlphaOnly="0" shadowOffsetUnit="MM" shadowOffsetDist="1" shadowUnder="0" shadowRadiusUnit="MM"/>
+        <dd_properties>
+          <Option type="Map">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+        </dd_properties>
+        <substitutions/>
+      </text-style>
+      <text-format useMaxLineLengthForAutoWrap="1" multilineAlign="1" placeDirectionSymbol="0" decimals="3" addDirectionSymbol="0" leftDirectionSymbol="&lt;" reverseDirectionSymbol="0" formatNumbers="0" plussign="0" wrapChar="@" rightDirectionSymbol=">" autoWrapLength="0"/>
+      <placement maxCurvedCharAngleIn="20" maxCurvedCharAngleOut="-20" layerType="PointGeometry" labelOffsetMapUnitScale="3x:0,0,0,0,0,0" xOffset="0" yOffset="0" geometryGeneratorType="PointGeometry" predefinedPositionOrder="TR,TL,BR,BL,R,L,TSR,BSR" geometryGeneratorEnabled="0" placement="0" repeatDistanceUnits="MM" quadOffset="4" distMapUnitScale="3x:0,0,0,0,0,0" repeatDistanceMapUnitScale="3x:0,0,0,0,0,0" geometryGenerator="" offsetUnits="MapUnit" repeatDistance="0" overrunDistanceMapUnitScale="3x:0,0,0,0,0,0" dist="3" distUnits="MM" rotationAngle="0" centroidWhole="0" preserveRotation="1" fitInPolygonOnly="0" priority="10" overrunDistance="0" overrunDistanceUnit="MM" centroidInside="0" offsetType="0" placementFlags="0"/>
+      <rendering scaleMin="1" scaleVisibility="0" minFeatureSize="0" fontMaxPixelSize="10000" mergeLines="0" drawLabels="1" displayAll="1" obstacle="1" scaleMax="5000" limitNumLabels="0" fontLimitPixelSize="0" labelPerPart="0" zIndex="0" obstacleFactor="1.4" upsidedownLabels="0" obstacleType="0" fontMinPixelSize="3" maxNumLabels="2000"/>
+      <dd_properties>
+        <Option type="Map">
+          <Option type="QString" value="" name="name"/>
+          <Option type="Map" name="properties">
+            <Option type="Map" name="AlwaysShow">
+              <Option type="bool" value="true" name="active"/>
+              <Option type="QString" value="&quot;fnouvass&quot;  IN ('07','_3', '04', '06', '_7') AND &quot;_source_historique&quot; != 'si2g'" name="expression"/>
+              <Option type="int" value="3" name="type"/>
+            </Option>
+            <Option type="Map" name="Color">
+              <Option type="bool" value="true" name="active"/>
+              <Option type="QString" value="CASE &#xa;&#x9;WHEN typreseau IN ('01') THEN '50,160,45,255' &#xa;&#x9;WHEN typreseau IN ('02') THEN '255,0,0,255' &#xa;&#x9;WHEN typreseau IN ('03') THEN '140,70,0,255' &#xa;&#x9;ELSE '161,161,161,255' &#xa;END" name="expression"/>
+              <Option type="int" value="3" name="type"/>
+            </Option>
+            <Option type="Map" name="Show">
+              <Option type="bool" value="true" name="active"/>
+              <Option type="QString" value="&quot;_source_historique&quot; != 'si2g' OR &quot;_source_historique&quot; IS NULL" name="expression"/>
+              <Option type="int" value="3" name="type"/>
+            </Option>
+          </Option>
+          <Option type="QString" value="collection" name="type"/>
+        </Option>
+      </dd_properties>
+      <callout type="simple">
+        <Option type="Map">
+          <Option type="QString" value="pole_of_inaccessibility" name="anchorPoint"/>
+          <Option type="Map" name="ddProperties">
+            <Option type="QString" value="" name="name"/>
+            <Option name="properties"/>
+            <Option type="QString" value="collection" name="type"/>
+          </Option>
+          <Option type="bool" value="false" name="drawToAllParts"/>
+          <Option type="QString" value="0" name="enabled"/>
+          <Option type="QString" value="&lt;symbol alpha=&quot;1&quot; clip_to_extent=&quot;1&quot; type=&quot;line&quot; force_rhr=&quot;0&quot; name=&quot;symbol&quot;>&lt;layer enabled=&quot;1&quot; class=&quot;SimpleLine&quot; locked=&quot;0&quot; pass=&quot;0&quot;>&lt;prop v=&quot;square&quot; k=&quot;capstyle&quot;/>&lt;prop v=&quot;5;2&quot; k=&quot;customdash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;customdash_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;customdash_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;draw_inside_polygon&quot;/>&lt;prop v=&quot;bevel&quot; k=&quot;joinstyle&quot;/>&lt;prop v=&quot;60,60,60,255&quot; k=&quot;line_color&quot;/>&lt;prop v=&quot;solid&quot; k=&quot;line_style&quot;/>&lt;prop v=&quot;0.3&quot; k=&quot;line_width&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;line_width_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;offset&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;offset_map_unit_scale&quot;/>&lt;prop v=&quot;MM&quot; k=&quot;offset_unit&quot;/>&lt;prop v=&quot;0&quot; k=&quot;ring_filter&quot;/>&lt;prop v=&quot;0&quot; k=&quot;use_custom_dash&quot;/>&lt;prop v=&quot;3x:0,0,0,0,0,0&quot; k=&quot;width_map_unit_scale&quot;/>&lt;data_defined_properties>&lt;Option type=&quot;Map&quot;>&lt;Option type=&quot;QString&quot; value=&quot;&quot; name=&quot;name&quot;/>&lt;Option name=&quot;properties&quot;/>&lt;Option type=&quot;QString&quot; value=&quot;collection&quot; name=&quot;type&quot;/>&lt;/Option>&lt;/data_defined_properties>&lt;/layer>&lt;/symbol>" name="lineSymbol"/>
+          <Option type="double" value="0" name="minLength"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="minLengthMapUnitScale"/>
+          <Option type="QString" value="MM" name="minLengthUnit"/>
+          <Option type="double" value="0" name="offsetFromAnchor"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromAnchorMapUnitScale"/>
+          <Option type="QString" value="MM" name="offsetFromAnchorUnit"/>
+          <Option type="double" value="0" name="offsetFromLabel"/>
+          <Option type="QString" value="3x:0,0,0,0,0,0" name="offsetFromLabelMapUnitScale"/>
+          <Option type="QString" value="MM" name="offsetFromLabelUnit"/>
+        </Option>
+      </callout>
+    </settings>
+  </labeling>
+  <customproperties>
+    <property key="dualview/previewExpressions" value="&quot;id&quot;"/>
+    <property key="embeddedWidgets/count" value="0"/>
+    <property key="variableNames"/>
+    <property key="variableValues"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerOpacity>1</layerOpacity>
+  <SingleCategoryDiagramRenderer attributeLegend="1" diagramType="Histogram">
+    <DiagramCategory scaleBasedVisibility="0" labelPlacementMethod="XHeight" enabled="0" scaleDependency="Area" sizeScale="3x:0,0,0,0,0,0" rotationOffset="270" penAlpha="255" minimumSize="0" width="15" height="15" backgroundColor="#ffffff" opacity="1" lineSizeType="MM" diagramOrientation="Up" barWidth="5" lineSizeScale="3x:0,0,0,0,0,0" minScaleDenominator="1" maxScaleDenominator="1e+08" backgroundAlpha="255" sizeType="MM" penWidth="0" penColor="#000000">
+      <fontProperties style="" description="Ubuntu,11,-1,5,50,0,0,0,0,0"/>
+      <attribute label="" color="#000000" field=""/>
+    </DiagramCategory>
+  </SingleCategoryDiagramRenderer>
+  <DiagramLayerSettings placement="0" linePlacementFlags="2" priority="0" showAll="1" zIndex="0" dist="0" obstacle="0">
+    <properties>
+      <Option type="Map">
+        <Option type="QString" value="" name="name"/>
+        <Option name="properties"/>
+        <Option type="QString" value="collection" name="type"/>
+      </Option>
+    </properties>
+  </DiagramLayerSettings>
+  <geometryOptions removeDuplicateNodes="0" geometryPrecision="0">
+    <activeChecks/>
+    <checkConfiguration/>
+  </geometryOptions>
+  <fieldConfiguration>
+    <field name="id">
+      <editWidget type="Range">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="AllowNull"/>
+            <Option type="int" value="2147483647" name="Max"/>
+            <Option type="int" value="-2147483648" name="Min"/>
+            <Option type="int" value="0" name="Precision"/>
+            <Option type="int" value="1" name="Step"/>
+            <Option type="QString" value="SpinBox" name="Style"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="idrepar">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="x">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="y">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="supprepare">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="code" name="Key"/>
+            <Option type="QString" value="val_raepa_support_reparation" name="LayerName"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="libelle" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="defreparee">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="code" name="Key"/>
+            <Option type="QString" value="val_raepa_type_defaillance" name="LayerName"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="libelle" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="idsuprepar">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="daterepar">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="allow_null"/>
+            <Option type="bool" value="true" name="calendar_popup"/>
+            <Option type="QString" value="yyyy-MM-dd" name="display_format"/>
+            <Option type="QString" value="yyyy-MM-dd" name="field_format"/>
+            <Option type="bool" value="false" name="field_iso_format"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="mouvrage">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="true" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="nom" name="Key"/>
+            <Option type="QString" value="sys_organisme_gestionnaire" name="LayerName"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="true" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="nom" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_typeintervention">
+      <editWidget type="ValueRelation">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="AllowMulti"/>
+            <Option type="bool" value="false" name="AllowNull"/>
+            <Option type="QString" value="" name="FilterExpression"/>
+            <Option type="QString" value="code" name="Key"/>
+            <Option type="QString" value="_val_raepa_type_intervention_ass_b7dfef5e_b05b_4fa5_af3b_ce4dcdd9c4ed" name="Layer"/>
+            <Option type="QString" value="_val_raepa_type_intervention_ass" name="LayerName"/>
+            <Option type="QString" value="postgres" name="LayerProviderName"/>
+            <Option type="QString" value="dbname='postgres' host=localhost port=5432 user='postgres' key='code' estimatedmetadata=true checkPrimaryKeyUnicity='1' table=&quot;raepa&quot;.&quot;_val_raepa_type_intervention_ass&quot; sql=" name="LayerSource"/>
+            <Option type="int" value="1" name="NofColumns"/>
+            <Option type="bool" value="false" name="OrderByValue"/>
+            <Option type="bool" value="false" name="UseCompleter"/>
+            <Option type="QString" value="libelle" name="Value"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_dateprevue">
+      <editWidget type="DateTime">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="allow_null"/>
+            <Option type="bool" value="true" name="calendar_popup"/>
+            <Option type="QString" value="yyyy-MM-dd" name="display_format"/>
+            <Option type="QString" value="yyyy-MM-dd" name="field_format"/>
+            <Option type="bool" value="false" name="field_iso_format"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_etatcanalisation">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_frequencecuragepreventif">
+      <editWidget type="Range">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="true" name="AllowNull"/>
+            <Option type="int" value="2147483647" name="Max"/>
+            <Option type="int" value="-2147483648" name="Min"/>
+            <Option type="int" value="0" name="Precision"/>
+            <Option type="int" value="1" name="Step"/>
+            <Option type="QString" value="SpinBox" name="Style"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_idinterventionparent">
+      <editWidget type="TextEdit">
+        <config>
+          <Option type="Map">
+            <Option type="bool" value="false" name="IsMultiline"/>
+            <Option type="bool" value="false" name="UseHtml"/>
+          </Option>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_source_historique">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+    <field name="_code_chantier">
+      <editWidget type="TextEdit">
+        <config>
+          <Option/>
+        </config>
+      </editWidget>
+    </field>
+  </fieldConfiguration>
+  <aliases>
+    <alias index="0" field="id" name="Identifiant automatique"/>
+    <alias index="1" field="idrepar" name=""/>
+    <alias index="2" field="x" name="X [m]"/>
+    <alias index="3" field="y" name="Y [m]"/>
+    <alias index="4" field="supprepare" name=""/>
+    <alias index="5" field="defreparee" name=""/>
+    <alias index="6" field="idsuprepar" name=""/>
+    <alias index="7" field="daterepar" name=""/>
+    <alias index="8" field="mouvrage" name="Maître d’ouvrage"/>
+    <alias index="9" field="_typeintervention" name=""/>
+    <alias index="10" field="_dateprevue" name=""/>
+    <alias index="11" field="_etatcanalisation" name=""/>
+    <alias index="12" field="_frequencecuragepreventif" name=""/>
+    <alias index="13" field="_idinterventionparent" name=""/>
+    <alias index="14" field="_source_historique" name=""/>
+    <alias index="15" field="_code_chantier" name=""/>
+  </aliases>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <defaults>
+    <default applyOnUpdate="0" expression="" field="id"/>
+    <default applyOnUpdate="0" expression="raepa.generate_oid('raepa_reparass_p'::text)" field="idrepar"/>
+    <default applyOnUpdate="0" expression="X( $geometry )" field="x"/>
+    <default applyOnUpdate="0" expression="Y( $geometry )" field="y"/>
+    <default applyOnUpdate="0" expression="" field="supprepare"/>
+    <default applyOnUpdate="0" expression="" field="defreparee"/>
+    <default applyOnUpdate="0" expression="'INCONNU'" field="idsuprepar"/>
+    <default applyOnUpdate="0" expression="" field="daterepar"/>
+    <default applyOnUpdate="0" expression="" field="mouvrage"/>
+    <default applyOnUpdate="0" expression="" field="_typeintervention"/>
+    <default applyOnUpdate="0" expression="" field="_dateprevue"/>
+    <default applyOnUpdate="0" expression="" field="_etatcanalisation"/>
+    <default applyOnUpdate="0" expression="" field="_frequencecuragepreventif"/>
+    <default applyOnUpdate="0" expression="" field="_idinterventionparent"/>
+    <default applyOnUpdate="0" expression="" field="_source_historique"/>
+    <default applyOnUpdate="0" expression="" field="_code_chantier"/>
+  </defaults>
+  <constraints>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" exp_strength="0" field="id"/>
+    <constraint unique_strength="1" constraints="3" notnull_strength="1" exp_strength="0" field="idrepar"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" exp_strength="0" field="x"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="2" exp_strength="0" field="y"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="supprepare"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="defreparee"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="idsuprepar"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="daterepar"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="mouvrage"/>
+    <constraint unique_strength="0" constraints="1" notnull_strength="1" exp_strength="0" field="_typeintervention"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_dateprevue"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_etatcanalisation"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_frequencecuragepreventif"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_idinterventionparent"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_source_historique"/>
+    <constraint unique_strength="0" constraints="0" notnull_strength="0" exp_strength="0" field="_code_chantier"/>
+  </constraints>
+  <constraintExpressions>
+    <constraint desc="" exp="" field="id"/>
+    <constraint desc="" exp="" field="idrepar"/>
+    <constraint desc="" exp="" field="x"/>
+    <constraint desc="" exp="" field="y"/>
+    <constraint desc="" exp="" field="supprepare"/>
+    <constraint desc="" exp="" field="defreparee"/>
+    <constraint desc="" exp="" field="idsuprepar"/>
+    <constraint desc="" exp="" field="daterepar"/>
+    <constraint desc="" exp="" field="mouvrage"/>
+    <constraint desc="" exp="" field="_typeintervention"/>
+    <constraint desc="" exp="" field="_dateprevue"/>
+    <constraint desc="" exp="" field="_etatcanalisation"/>
+    <constraint desc="" exp="" field="_frequencecuragepreventif"/>
+    <constraint desc="" exp="" field="_idinterventionparent"/>
+    <constraint desc="" exp="" field="_source_historique"/>
+    <constraint desc="" exp="" field="_code_chantier"/>
+  </constraintExpressions>
+  <expressionfields/>
+  <attributeactions>
+    <defaultAction key="Canvas" value="{00000000-0000-0000-0000-000000000000}"/>
+    <actionsetting shortTitle="" icon="" type="1" id="{6e7734c4-d839-4a8c-9d96-12a16b8bd5de}" action="from qgis.utils import plugins&#xa;plugins['raepa'].run_action(&#xa;    'parcourir_reseau_depuis_cet_objet',&#xa;    '[% idouvrage %]',&#xa;    0&#xa;)" capture="0" notificationMessage="" name="Parcourir le réseau depuis cet objet" isEnabledOnlyWhenEditable="0">
+      <actionScope id="Feature"/>
+      <actionScope id="Field"/>
+      <actionScope id="Canvas"/>
+    </actionsetting>
+    <actionsetting shortTitle="" icon="" type="1" id="{d18c9da5-acfd-4ca3-9d93-30147561b5b9}" action="from qgis.utils import plugins&#xa;plugins['raepa'].run_action(&#xa;    'ouvrage_annuler_derniere_modification',&#xa;    '[% idouvrage %]',&#xa;    '[% @layer_id %]'&#xa;)" capture="0" notificationMessage="" name="Annuler la dernière modification" isEnabledOnlyWhenEditable="0">
+      <actionScope id="Feature"/>
+      <actionScope id="Canvas"/>
+    </actionsetting>
+  </attributeactions>
+  <attributetableconfig sortExpression="&quot;idouvrage&quot;" actionWidgetStyle="dropDown" sortOrder="1">
+    <columns>
+      <column width="242" type="actions" hidden="0"/>
+      <column width="-1" type="field" hidden="1" name="x"/>
+      <column width="-1" type="field" hidden="1" name="y"/>
+      <column width="-1" type="field" hidden="1" name="mouvrage"/>
+      <column width="-1" type="field" hidden="0" name="id"/>
+      <column width="-1" type="field" hidden="0" name="idrepar"/>
+      <column width="-1" type="field" hidden="0" name="supprepare"/>
+      <column width="-1" type="field" hidden="0" name="defreparee"/>
+      <column width="-1" type="field" hidden="0" name="idsuprepar"/>
+      <column width="-1" type="field" hidden="0" name="daterepar"/>
+      <column width="-1" type="field" hidden="0" name="_typeintervention"/>
+      <column width="-1" type="field" hidden="0" name="_dateprevue"/>
+      <column width="-1" type="field" hidden="0" name="_etatcanalisation"/>
+      <column width="-1" type="field" hidden="0" name="_frequencecuragepreventif"/>
+      <column width="-1" type="field" hidden="0" name="_idinterventionparent"/>
+      <column width="-1" type="field" hidden="0" name="_source_historique"/>
+      <column width="-1" type="field" hidden="0" name="_code_chantier"/>
+    </columns>
+  </attributetableconfig>
+  <conditionalstyles>
+    <rowstyles/>
+    <fieldstyles/>
+  </conditionalstyles>
+  <storedexpressions/>
+  <editform tolerant="1">/../../../.local/share/QGIS/QGIS3/profiles</editform>
+  <editforminit>vw_cover_open</editforminit>
+  <editforminitcodesource>0</editforminitcodesource>
+  <editforminitfilepath>/../.local/share/QGIS/.local/share/QGIS/QGIS3/profiles/default/3liz/Reapa</editforminitfilepath>
+  <editforminitcode><![CDATA[from qgepplugin.ui.forms import vw_cover_open
+]]></editforminitcode>
+  <featformsuppress>0</featformsuppress>
+  <editorlayout>tablayout</editorlayout>
+  <attributeEditorForm>
+    <attributeEditorContainer showLabel="1" groupBox="0" visibilityExpression="" columnCount="1" name="Reparation" visibilityExpressionEnabled="0">
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Général" visibilityExpressionEnabled="0">
+        <attributeEditorField index="0" showLabel="1" name="id"/>
+        <attributeEditorField index="1" showLabel="1" name="idrepar"/>
+        <attributeEditorField index="5" showLabel="1" name="defreparee"/>
+        <attributeEditorField index="9" showLabel="1" name="_typeintervention"/>
+        <attributeEditorField index="11" showLabel="1" name="_etatcanalisation"/>
+        <attributeEditorField index="12" showLabel="1" name="_frequencecuragepreventif"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Technique" visibilityExpressionEnabled="0">
+        <attributeEditorField index="2" showLabel="1" name="x"/>
+        <attributeEditorField index="3" showLabel="1" name="y"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Relations" visibilityExpressionEnabled="0">
+        <attributeEditorField index="4" showLabel="1" name="supprepare"/>
+        <attributeEditorField index="6" showLabel="1" name="idsuprepar"/>
+        <attributeEditorField index="13" showLabel="1" name="_idinterventionparent"/>
+      </attributeEditorContainer>
+      <attributeEditorContainer showLabel="1" groupBox="1" visibilityExpression="" columnCount="1" name="Historique" visibilityExpressionEnabled="0">
+        <attributeEditorField index="8" showLabel="1" name="mouvrage"/>
+        <attributeEditorField index="7" showLabel="1" name="daterepar"/>
+        <attributeEditorField index="10" showLabel="1" name="_dateprevue"/>
+      </attributeEditorContainer>
+    </attributeEditorContainer>
+  </attributeEditorForm>
+  <editable>
+    <field editable="1" name="_angletampon"/>
+    <field editable="1" name="_capacite"/>
+    <field editable="1" name="_code_chantier"/>
+    <field editable="1" name="_commune"/>
+    <field editable="1" name="_date_import"/>
+    <field editable="1" name="_dateprevue"/>
+    <field editable="1" name="_etatcanalisation"/>
+    <field editable="1" name="_fiche"/>
+    <field editable="1" name="_frequencecuragepreventif"/>
+    <field editable="1" name="_geom_emprise"/>
+    <field editable="1" name="_idinterventionparent"/>
+    <field editable="1" name="_image"/>
+    <field editable="1" name="_nom_appareil"/>
+    <field editable="1" name="_observation"/>
+    <field editable="1" name="_source_historique"/>
+    <field editable="1" name="_temp_data"/>
+    <field editable="1" name="_typeintervention"/>
+    <field editable="1" name="_ztampon"/>
+    <field editable="1" name="andebpose"/>
+    <field editable="1" name="anfinpose"/>
+    <field editable="1" name="dategeoloc"/>
+    <field editable="1" name="datemaj"/>
+    <field editable="1" name="daterepar"/>
+    <field editable="1" name="defreparee"/>
+    <field editable="1" name="fnouvass"/>
+    <field editable="1" name="gexploit"/>
+    <field editable="0" name="id"/>
+    <field editable="1" name="idcanamont"/>
+    <field editable="1" name="idcanaval"/>
+    <field editable="1" name="idcanppale"/>
+    <field editable="1" name="idouvrage"/>
+    <field editable="1" name="idrepar"/>
+    <field editable="1" name="idsuprepar"/>
+    <field editable="1" name="mouvrage"/>
+    <field editable="1" name="qualannee"/>
+    <field editable="1" name="qualglocxy"/>
+    <field editable="1" name="qualglocz"/>
+    <field editable="1" name="sourattrib"/>
+    <field editable="1" name="sourgeoloc"/>
+    <field editable="1" name="sourmaj"/>
+    <field editable="1" name="supprepare"/>
+    <field editable="1" name="typreseau"/>
+    <field editable="1" name="x"/>
+    <field editable="1" name="y"/>
+    <field editable="1" name="z"/>
+  </editable>
+  <labelOnTop>
+    <field labelOnTop="0" name="_angletampon"/>
+    <field labelOnTop="0" name="_capacite"/>
+    <field labelOnTop="0" name="_code_chantier"/>
+    <field labelOnTop="0" name="_commune"/>
+    <field labelOnTop="0" name="_date_import"/>
+    <field labelOnTop="0" name="_dateprevue"/>
+    <field labelOnTop="0" name="_etatcanalisation"/>
+    <field labelOnTop="0" name="_fiche"/>
+    <field labelOnTop="0" name="_frequencecuragepreventif"/>
+    <field labelOnTop="0" name="_geom_emprise"/>
+    <field labelOnTop="0" name="_idinterventionparent"/>
+    <field labelOnTop="0" name="_image"/>
+    <field labelOnTop="0" name="_nom_appareil"/>
+    <field labelOnTop="0" name="_observation"/>
+    <field labelOnTop="0" name="_source_historique"/>
+    <field labelOnTop="0" name="_temp_data"/>
+    <field labelOnTop="0" name="_typeintervention"/>
+    <field labelOnTop="0" name="_ztampon"/>
+    <field labelOnTop="0" name="andebpose"/>
+    <field labelOnTop="0" name="anfinpose"/>
+    <field labelOnTop="0" name="dategeoloc"/>
+    <field labelOnTop="0" name="datemaj"/>
+    <field labelOnTop="0" name="daterepar"/>
+    <field labelOnTop="0" name="defreparee"/>
+    <field labelOnTop="0" name="fnouvass"/>
+    <field labelOnTop="0" name="gexploit"/>
+    <field labelOnTop="0" name="id"/>
+    <field labelOnTop="0" name="idcanamont"/>
+    <field labelOnTop="0" name="idcanaval"/>
+    <field labelOnTop="0" name="idcanppale"/>
+    <field labelOnTop="0" name="idouvrage"/>
+    <field labelOnTop="0" name="idrepar"/>
+    <field labelOnTop="0" name="idsuprepar"/>
+    <field labelOnTop="0" name="mouvrage"/>
+    <field labelOnTop="0" name="qualannee"/>
+    <field labelOnTop="0" name="qualglocxy"/>
+    <field labelOnTop="0" name="qualglocz"/>
+    <field labelOnTop="0" name="sourattrib"/>
+    <field labelOnTop="0" name="sourgeoloc"/>
+    <field labelOnTop="0" name="sourmaj"/>
+    <field labelOnTop="0" name="supprepare"/>
+    <field labelOnTop="0" name="typreseau"/>
+    <field labelOnTop="0" name="x"/>
+    <field labelOnTop="0" name="y"/>
+    <field labelOnTop="0" name="z"/>
+  </labelOnTop>
+  <widgets>
+    <widget name="_label_x">
+      <config/>
+    </widget>
+    <widget name="_label_y">
+      <config/>
+    </widget>
+    <widget name="od_file20160921105557083_object_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="re_maintenance_event_wastewater_structure_fk_wastewater_structure_vw_qgep_wastewater_structure_ws_obj_id">
+      <config/>
+    </widget>
+    <widget name="sys_parcours_reseau20171207183948125_idouvrage_raepa_ouvrass_p_geom20171203161907366_idouvrage">
+      <config/>
+    </widget>
+    <widget name="vw_access_aid20150507162234295_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_access_aid_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_backflow_prevention20150531093552085_fk_wastewater_structure_vw_qgep_wastewater_structure_ws_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_backflow_prevention_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_benching20150507162234281_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_benching_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_cover20150507162234308_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_cover____fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_downspout20150507162234268_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_downspout_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_flume20150507162234250_fk_wastewater_structure_vw_qgep_wastewater_structure20150506155849784_obj_id">
+      <config/>
+    </widget>
+    <widget name="vw_dryweather_flume_fk_wastewater_structure_vw_qgep_wastewater_structure_obj_id">
+      <config/>
+    </widget>
+    <widget name="wastewater_node-fk_wastewater-structure">
+      <config/>
+    </widget>
+  </widgets>
+  <previewExpression>"id"</previewExpression>
+  <mapTip></mapTip>
+  <layerGeometryType>0</layerGeometryType>
+</qgis>


### PR DESCRIPTION
Permet de donner un style au couches de réparation via l'outils `Charger les styles`.
Trois fichiers de style sont disponibles, un pour les actions, un pour les formulaires et un pour tout les styles.